### PR TITLE
fix: pin @types/fs-extra to 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@semantic-release/git": "^5.0.0",
     "@types/detect-indent": "^5.0.0",
     "@types/detect-newline": "^2.1.0",
-    "@types/fs-extra": "^5.0.2",
+    "@types/fs-extra": "5.0.2",
     "@types/jest": "^23.0.0",
     "@types/node": "^10.1.2",
     "codecov": "^3.0.2",


### PR DESCRIPTION
## Description

There are some issues with the new `@types/fs-extra`, mentioned in [PR #26381](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26381). This is the same issue reported by Greenkeeper.