### PR TITLE
fix: set jsdom test url for local storage support

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 			"json"
 		],
 		"testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+		"testURL": "http://localhost/",
 		"transform": {
 			"^.+\\.tsx?$": "ts-jest"
 		}


### PR DESCRIPTION
## Description

This is a workaround for issue [#6766](https://github.com/facebook/jest/issues/6766) and mentioned in [#2304](https://github.com/jsdom/jsdom/issues/2304).