### PR TITLE
fix: make Android version deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An [Expo][expo] implementation for [semantic release][semantic-release], so you 
 Semantic release will first determine a new version based on your likings. 
 Then this plugin will search for your [Expo manifest][expo-manifest] and update it accordingly. 
 Not only will this update the [`version`][expo-version] property within the manifest. 
-It will set the version to the [iOS `buildNumber`][expo-version-ios] and also set the [Android `versionCode`][expo-version-android] to the following schema: `{major,2}{minor,2}{patch,2}`.
+It will set the version to the [iOS `buildNumber`][expo-version-ios] and also set the [Android `versionCode`][expo-version-android] to the following schema: `{expoSDKMajor,2}0{major,2}{minor,2}{patch,2}`.
 
 ## Verify Conditions
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An [Expo][expo] implementation for [semantic release][semantic-release], so you 
 Semantic release will first determine a new version based on your likings. 
 Then this plugin will search for your [Expo manifest][expo-manifest] and update it accordingly. 
 Not only will this update the [`version`][expo-version] property within the manifest. 
-It will also increment the [Android `versionCode`][expo-version-android] or set the version to the [iOS `buildNumber`][expo-version-ios].
+It will set the version to the [iOS `buildNumber`][expo-version-ios] and also set the [Android `versionCode`][expo-version-android] to the following schema: `{major,2}{minor,2}{patch,2}`.
 
 ## Verify Conditions
 

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
 	},
 	"peerDependencies": {},
 	"dependencies": {
+		"@types/semver": "^5.5.0",
 		"detect-indent": "^5.0.0",
 		"detect-newline": "^2.1.0",
-		"fs-extra": "^7.0.0"
+		"fs-extra": "^7.0.0",
+		"semver": "^5.5.1"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^7.0.0",

--- a/src/version-bumpers/platform-android.ts
+++ b/src/version-bumpers/platform-android.ts
@@ -6,7 +6,7 @@ const bumpPlatformAndroid: VersionBumper = (meta, context) => {
 	const sdkVersion = semver.coerce(meta.manifest.sdkVersion || 0);
 	const android = getAndroidPlatform(meta.manifest);
 	const oldVersion = android.versionCode || 0;
-    const nextRelease = semver.coerce(context.nextRelease!.version);
+	const nextRelease = semver.coerce(context.nextRelease!.version);
 	const newVersion = sdkVersion!.major * 10000000 + nextRelease!.major * 10000 + nextRelease!.minor * 100 + nextRelease!.patch;
 
 	context.logger.log(

--- a/src/version-bumpers/platform-android.ts
+++ b/src/version-bumpers/platform-android.ts
@@ -3,10 +3,11 @@ import { getAndroidPlatform } from '../expo';
 import { VersionBumper } from '../types';
 
 const bumpPlatformAndroid: VersionBumper = (meta, context) => {
+	const sdkVersion = semver.coerce(meta.manifest.sdkVersion || 0);
 	const android = getAndroidPlatform(meta.manifest);
 	const oldVersion = android.versionCode || 0;
     const nextRelease = semver.coerce(context.nextRelease!.version);
-	const newVersion = nextRelease!.major * 10000 + nextRelease!.minor * 100 + nextRelease!.patch;
+	const newVersion = sdkVersion!.major * 10000000 + nextRelease!.major * 10000 + nextRelease!.minor * 100 + nextRelease!.patch;
 
 	context.logger.log(
 		'%s manifest android version changed (%s => %s) in %s',

--- a/src/version-bumpers/platform-android.ts
+++ b/src/version-bumpers/platform-android.ts
@@ -1,10 +1,12 @@
+import * as semver from 'semver';
 import { getAndroidPlatform } from '../expo';
 import { VersionBumper } from '../types';
 
 const bumpPlatformAndroid: VersionBumper = (meta, context) => {
 	const android = getAndroidPlatform(meta.manifest);
 	const oldVersion = android.versionCode || 0;
-	const newVersion = oldVersion + 1;
+    const nextRelease = semver.coerce(context.nextRelease!.version);
+	const newVersion = nextRelease!.major * 10000 + nextRelease!.minor * 100 + nextRelease!.patch;
 
 	context.logger.log(
 		'%s manifest android version changed (%s => %s) in %s',

--- a/test/version-bumpers/platform-android.test.ts
+++ b/test/version-bumpers/platform-android.test.ts
@@ -22,7 +22,7 @@ describe('version-bumpers/platform-android', () => {
 		const oldManifest = {
 			name: 'test',
 			version: '1.2.0',
-			android: { versionCode: 6 },
+			android: { versionCode: 10200 },
 			ios: { buildNumber: '1.2.0' },
 		};
 
@@ -40,15 +40,15 @@ describe('version-bumpers/platform-android', () => {
 		expect(context.logger.log).toBeCalledWith(
 			'%s manifest android version changed (%s => %s) in %s',
 			'Expo',
-			6,
-			7,
+			10200,
+			10300,
 			'app.json',
 		);
 
 		expect(newManifest).toMatchObject({
 			name: 'test',
 			version: '1.2.0',
-			android: { versionCode: 7 },
+			android: { versionCode: 10300 },
 			ios: { buildNumber: '1.2.0' },
 		});
 	});

--- a/test/version-bumpers/platform-android.test.ts
+++ b/test/version-bumpers/platform-android.test.ts
@@ -22,7 +22,8 @@ describe('version-bumpers/platform-android', () => {
 		const oldManifest = {
 			name: 'test',
 			version: '1.2.0',
-			android: { versionCode: 10200 },
+			sdkVersion: '29.0.0',
+			android: { versionCode: 290010200 },
 			ios: { buildNumber: '1.2.0' },
 		};
 
@@ -40,15 +41,16 @@ describe('version-bumpers/platform-android', () => {
 		expect(context.logger.log).toBeCalledWith(
 			'%s manifest android version changed (%s => %s) in %s',
 			'Expo',
-			10200,
-			10300,
+			290010200,
+			290010300,
 			'app.json',
 		);
 
 		expect(newManifest).toMatchObject({
 			name: 'test',
 			version: '1.2.0',
-			android: { versionCode: 10300 },
+			sdkVersion: '29.0.0',
+			android: { versionCode: 290010300 },
 			ios: { buildNumber: '1.2.0' },
 		});
 	});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The Android version will be calculated based on the version string.

## Motivation and context

Currently, the Android version is not deterministic and always depends on the predecessor. This is a challenge if the Android version was accidentally overwritten in `app.json`.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.
Please, please, please, don't send your pull request until all of the boxes are ticked.

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses _exactly one_ patch/feature.
- [X] I have created a _branch_ for this patch/feature.
- [X] Each individual _commit_ in the pull request _is meaningful_.
- [X] I have _added tests_ to cover my changes.
- [X] If my change requires a change to the _documentation_, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
