### PR TITLE
fix: force android version code to numeric value

### DIFF
--- a/src/version-bumpers/platform-android.ts
+++ b/src/version-bumpers/platform-android.ts
@@ -4,7 +4,7 @@ import { calculateAndroidVersion } from '../version';
 
 const bumpPlatformAndroid: VersionBumper = (meta, config, context) => {
 	const android = getAndroidPlatform(meta.manifest);
-	const newVersion = calculateAndroidVersion(meta, config, context);
+	const newVersion = parseInt(calculateAndroidVersion(meta, config, context), 10);
 
 	context.logger.log(
 		'%s manifest android version changed (%s => %s) in %s',

--- a/test/version-bumpers/platform-android.test.ts
+++ b/test/version-bumpers/platform-android.test.ts
@@ -33,7 +33,7 @@ describe('version-bumpers/platform-android', () => {
 		});
 
 		getAndroidPlatform.mockReturnValue(meta.manifest.android);
-		calculateAndroidVersion.mockReturnValue(290010300);
+		calculateAndroidVersion.mockReturnValue('290010300');
 
 		const manifest = bumpPlatformAndroid(meta, config, context);
 


### PR DESCRIPTION
This fixes issues with lodash template transforming the result to string. Also, tests are updated for this usecase (although not explicitly defined).

### Linked issue
Fixes #42 
