### PR TITLE
Greenkeeper/@types/node 11.10.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1122,9 +1122,9 @@
 			"integrity": "sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ=="
 		},
 		"@types/node": {
-			"version": "11.9.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
-			"integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==",
+			"version": "11.10.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.5.tgz",
+			"integrity": "sha512-DuIRlQbX4K+d5I+GMnv+UfnGh+ist0RdlvOp+JZ7ePJ6KQONCFQv/gKYSU1ZzbVdFSUCKZOltjmpFAGGv5MdYA==",
 			"dev": true
 		},
 		"@types/semver": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@types/detect-newline": "^2.1.0",
 		"@types/fs-extra": "^5.0.5",
 		"@types/jest": "^24.0.6",
-		"@types/node": "^11.9.5",
+		"@types/node": "^11.10.5",
 		"codecov": "^3.2.0",
 		"jest": "^24.0.0",
 		"ts-jest": "^24.0.0",


### PR DESCRIPTION
### Linked issue
Update the `@types/node` branch to latest version and see if problems persists.

Fixes #70 