### PR TITLE
pipeline: add node 12 to testing languages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: node_js
 node_js:
+  - 12
   - 11
   - 10
   - 8


### PR DESCRIPTION
### Linked issue
Let's add the new to-be-lts node version 12 to the testing list.