### PR TITLE
refactor: use dependabot instead of greenkeeper

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+---
+version: 1
+update_configs:
+  - package_manager: javascript
+    directory: /
+    update_schedule: live
+    default_reviewers:
+      - bycedric
+    default_labels:
+      - upgrade

--- a/package.json
+++ b/package.json
@@ -93,24 +93,5 @@
 	},
 	"release": {
 		"extends": "@peakfijn/config-release"
-	},
-	"greenkeeper": {
-		"commitMessages": {
-			"initialBadge": "documentation: add greenkeeper badge",
-			"initialDependencies": "chore: update dependencies",
-			"initialBranches": "chore: whitelist greenkeeper branches",
-			"dependencyUpdate": "refactor: upgrade ${dependency} to version ${version}",
-			"devDependencyUpdate": "refactor: upgrade ${dependency} to version ${version}",
-			"dependencyPin": "fix: freeze ${dependency} to ${oldVersion}",
-			"devDependencyPin": "fix: freeze ${dependency} to ${oldVersion}"
-		},
-		"prTitles": {
-			"initialPR": "refactor: upgrade all dependencies to enable greenkeeper",
-			"initialPrBadge": "documentation: add greenkeeper badge",
-			"initialPrBadgeOnly": "documentation: add greenkeeper badge",
-			"initialSubgroupPR": "refactor(${group}): upgrade ${dependency} to version ${version}",
-			"basicPR": "refactor: upgrade ${dependency} to version ${version}",
-			"groupPR": "refactor(${group}): upgrade ${dependency} to version ${version}"
-		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
 				2,
 				"always",
 				[
-					"package"
+					"deps",
+					"deps-dev"
 				]
 			]
 		}


### PR DESCRIPTION
### Linked issue
Moving over from Greenkeeper to Dependabot because it's now "part of GitHub".