### PR TITLE
Lower the dependabot pr intensity

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,7 +3,7 @@ version: 1
 update_configs:
   - package_manager: javascript
     directory: /
-    update_schedule: live
+    update_schedule: monthly
     default_reviewers:
       - bycedric
     default_labels:


### PR DESCRIPTION
### Linked issue
It's kind of spammy for patch versions. Until the automerge functionality is released lets ease up dependabot and make it a monthly check.
