### PR TITLE
pipeline: remove audit step to ease up on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
   directories:
     - ~/.npm
 install:
-  - npm audit || echo 'Make it unblocking awaiting tar/node-gyp fix'
   - npm ci
 script:
   - npx commitlint-travis


### PR DESCRIPTION
### Linked issue
Right now it errors too much with Jest and other dependencies. Let's keep this on local machines instead.
