### PR TITLE
refactor: move types dependencies to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1086,6 +1086,114 @@
 				"semantic-release": "^15.13.2"
 			},
 			"dependencies": {
+				"@semantic-release/npm": {
+					"version": "5.1.14",
+					"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.14.tgz",
+					"integrity": "sha512-HQYqA9Ne7uEi+5M0tuZCCaL5TOI8hSyFGIJa8FEUUBH+1sBJA2ACOlPHnLq7emj1SNBp1/+rgfbgIee9RYNjzQ==",
+					"dev": true,
+					"requires": {
+						"@semantic-release/error": "^2.2.0",
+						"aggregate-error": "^3.0.0",
+						"execa": "^2.0.2",
+						"fs-extra": "^8.0.0",
+						"lodash": "^4.17.4",
+						"nerf-dart": "^1.0.0",
+						"normalize-url": "^4.0.0",
+						"npm": "^6.8.0",
+						"rc": "^1.2.8",
+						"read-pkg": "^5.0.0",
+						"registry-auth-token": "^4.0.0"
+					},
+					"dependencies": {
+						"aggregate-error": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz",
+							"integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
+							"dev": true,
+							"requires": {
+								"clean-stack": "^2.0.0",
+								"indent-string": "^3.2.0"
+							}
+						},
+						"execa": {
+							"version": "2.0.3",
+							"resolved": "https://registry.npmjs.org/execa/-/execa-2.0.3.tgz",
+							"integrity": "sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==",
+							"dev": true,
+							"requires": {
+								"cross-spawn": "^6.0.5",
+								"get-stream": "^5.0.0",
+								"is-stream": "^2.0.0",
+								"merge-stream": "^2.0.0",
+								"npm-run-path": "^3.0.0",
+								"onetime": "^5.1.0",
+								"p-finally": "^2.0.0",
+								"signal-exit": "^3.0.2",
+								"strip-final-newline": "^2.0.0"
+							}
+						},
+						"get-stream": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+							"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+							"dev": true,
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						},
+						"is-stream": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+							"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+							"dev": true
+						},
+						"npm-run-path": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+							"integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+							"dev": true,
+							"requires": {
+								"path-key": "^3.0.0"
+							}
+						},
+						"p-finally": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+							"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+							"dev": true
+						},
+						"parse-json": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+							"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.0.0",
+								"error-ex": "^1.3.1",
+								"json-parse-better-errors": "^1.0.1",
+								"lines-and-columns": "^1.1.6"
+							}
+						},
+						"path-key": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+							"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+							"dev": true
+						},
+						"read-pkg": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+							"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+							"dev": true,
+							"requires": {
+								"@types/normalize-package-data": "^2.4.0",
+								"normalize-package-data": "^2.5.0",
+								"parse-json": "^5.0.0",
+								"type-fest": "^0.6.0"
+							}
+						}
+					}
+				},
 				"cosmiconfig": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
@@ -1181,11 +1289,32 @@
 						"path-exists": "^3.0.0"
 					}
 				},
+				"merge-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+					"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+					"dev": true
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
+				},
+				"onetime": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
 				},
 				"p-limit": {
 					"version": "2.2.0",
@@ -1509,92 +1638,6 @@
 				}
 			}
 		},
-		"@semantic-release/npm": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.4.tgz",
-			"integrity": "sha512-YRl8VTVwnRTl/sVRvTXs1ncYcuvuGrqPEXYy+lUK1YRLq25hkrhIdv3Ju0u1zGLqVCA8qRlF3NzWl7pULJXVog==",
-			"dev": true,
-			"requires": {
-				"@semantic-release/error": "^2.2.0",
-				"aggregate-error": "^2.0.0",
-				"execa": "^1.0.0",
-				"fs-extra": "^7.0.0",
-				"lodash": "^4.17.4",
-				"nerf-dart": "^1.0.0",
-				"normalize-url": "^4.0.0",
-				"npm": "6.5.0",
-				"rc": "^1.2.8",
-				"read-pkg": "^4.0.0",
-				"registry-auth-token": "^3.3.1"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"execa": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
-					"integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
-					"dev": true,
-					"requires": {
-						"normalize-package-data": "^2.3.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
-				}
-			}
-		},
 		"@semantic-release/release-notes-generator": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-7.1.4.tgz",
@@ -1777,7 +1820,8 @@
 		"@types/lodash": {
 			"version": "4.14.134",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
-			"integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw=="
+			"integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw==",
+			"dev": true
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -1791,10 +1835,17 @@
 			"integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==",
 			"dev": true
 		},
+		"@types/normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+			"dev": true
+		},
 		"@types/semver": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.0.tgz",
-			"integrity": "sha512-OO0srjOGH99a4LUN2its3+r6CBYcplhJ466yLqs+zvAWgphCpS8hYZEZ797tRDP/QKcqTdb/YCN6ifASoAWkrQ=="
+			"integrity": "sha512-OO0srjOGH99a4LUN2its3+r6CBYcplhJ466yLqs+zvAWgphCpS8hYZEZ797tRDP/QKcqTdb/YCN6ifASoAWkrQ==",
+			"dev": true
 		},
 		"@types/stack-utils": {
 			"version": "1.0.1",
@@ -2523,7 +2574,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
 			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"ci-info": {
 			"version": "2.0.0",
@@ -3759,6 +3811,7 @@
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
 			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"minipass": "^2.2.1"
 			}
@@ -4001,7 +4054,6 @@
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -4197,8 +4249,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4288,8 +4339,7 @@
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				}
 			}
 		},
@@ -5901,6 +5951,12 @@
 				"type-check": "~0.3.2"
 			}
 		},
+		"lines-and-columns": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+			"dev": true
+		},
 		"load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -6297,6 +6353,7 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -6306,7 +6363,8 @@
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -6315,14 +6373,15 @@
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
 			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"minipass": "^2.2.1"
 			}
 		},
 		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -6509,26 +6568,26 @@
 			"dev": true
 		},
 		"npm": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-6.5.0.tgz",
-			"integrity": "sha512-SPq8zG2Kto+Xrq55E97O14Jla13PmQT5kSnvwBj88BmJZ5Nvw++OmlWfhjkB67pcgP5UEXljEtnGFKZtOgt6MQ==",
+			"version": "6.10.1",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-6.10.1.tgz",
+			"integrity": "sha512-ejR83c5aPTip5hPhziypqkJu06vb5tDIugCXx1c5+04RbMjtZeMA6BfsuGnV9EBdEwzKoaHkQ9sJWQAq+LjHYw==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "^1.3.4",
+				"JSONStream": "^1.3.5",
 				"abbrev": "~1.1.1",
 				"ansicolors": "~0.3.2",
 				"ansistyles": "~0.1.3",
-				"aproba": "~1.2.0",
+				"aproba": "^2.0.0",
 				"archy": "~1.0.0",
 				"bin-links": "^1.1.2",
-				"bluebird": "^3.5.3",
-				"byte-size": "^4.0.3",
-				"cacache": "^11.2.0",
-				"call-limit": "~1.1.0",
-				"chownr": "~1.0.1",
-				"ci-info": "^1.6.0",
+				"bluebird": "^3.5.5",
+				"byte-size": "^5.0.1",
+				"cacache": "^11.3.3",
+				"call-limit": "^1.1.1",
+				"chownr": "^1.1.2",
+				"ci-info": "^2.0.0",
 				"cli-columns": "^3.1.2",
-				"cli-table3": "^0.5.0",
+				"cli-table3": "^0.5.1",
 				"cmd-shim": "~2.0.2",
 				"columnify": "~1.5.4",
 				"config-chain": "^1.1.12",
@@ -6542,23 +6601,28 @@
 				"fs-vacuum": "~1.2.10",
 				"fs-write-stream-atomic": "~1.0.10",
 				"gentle-fs": "^2.0.1",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.1.15",
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.2.0",
 				"has-unicode": "~2.0.1",
 				"hosted-git-info": "^2.7.1",
 				"iferr": "^1.0.2",
 				"imurmurhash": "*",
 				"inflight": "~1.0.6",
-				"inherits": "~2.0.3",
+				"inherits": "^2.0.4",
 				"ini": "^1.3.5",
 				"init-package-json": "^1.10.3",
-				"is-cidr": "^2.0.6",
+				"is-cidr": "^3.0.0",
 				"json-parse-better-errors": "^1.0.2",
 				"lazy-property": "~1.0.0",
-				"libcipm": "^2.0.2",
-				"libnpmhook": "^4.0.1",
+				"libcipm": "^4.0.0",
+				"libnpm": "^3.0.0",
+				"libnpmaccess": "*",
+				"libnpmhook": "^5.0.2",
+				"libnpmorg": "*",
+				"libnpmsearch": "^2.0.1",
+				"libnpmteam": "*",
 				"libnpx": "^10.2.0",
-				"lock-verify": "^2.0.2",
+				"lock-verify": "^2.1.0",
 				"lockfile": "^1.0.4",
 				"lodash._baseindexof": "*",
 				"lodash._baseuniq": "~4.6.0",
@@ -6571,71 +6635,70 @@
 				"lodash.union": "~4.6.0",
 				"lodash.uniq": "~4.5.0",
 				"lodash.without": "~4.4.0",
-				"lru-cache": "^4.1.3",
+				"lru-cache": "^5.1.1",
 				"meant": "~1.0.1",
 				"mississippi": "^3.0.0",
 				"mkdirp": "~0.5.1",
 				"move-concurrently": "^1.0.1",
-				"node-gyp": "^3.8.0",
+				"node-gyp": "^5.0.2",
 				"nopt": "~4.0.1",
-				"normalize-package-data": "~2.4.0",
-				"npm-audit-report": "^1.3.1",
+				"normalize-package-data": "^2.5.0",
+				"npm-audit-report": "^1.3.2",
 				"npm-cache-filename": "~1.0.2",
 				"npm-install-checks": "~3.0.0",
-				"npm-lifecycle": "^2.1.0",
+				"npm-lifecycle": "^3.0.0",
 				"npm-package-arg": "^6.1.0",
-				"npm-packlist": "^1.1.12",
-				"npm-pick-manifest": "^2.1.0",
-				"npm-profile": "^3.0.2",
-				"npm-registry-client": "^8.6.0",
-				"npm-registry-fetch": "^1.1.0",
+				"npm-packlist": "^1.4.4",
+				"npm-pick-manifest": "^2.2.3",
+				"npm-profile": "*",
+				"npm-registry-fetch": "^3.9.1",
 				"npm-user-validate": "~1.0.0",
 				"npmlog": "~4.1.2",
 				"once": "~1.4.0",
 				"opener": "^1.5.1",
 				"osenv": "^0.1.5",
-				"pacote": "^8.1.6",
+				"pacote": "^9.5.1",
 				"path-is-inside": "~1.0.2",
 				"promise-inflight": "~1.0.1",
 				"qrcode-terminal": "^0.12.0",
-				"query-string": "^6.1.0",
+				"query-string": "^6.8.1",
 				"qw": "~1.0.1",
 				"read": "~1.0.7",
 				"read-cmd-shim": "~1.0.1",
 				"read-installed": "~4.0.3",
 				"read-package-json": "^2.0.13",
-				"read-package-tree": "^5.2.1",
-				"readable-stream": "^2.3.6",
-				"readdir-scoped-modules": "*",
+				"read-package-tree": "^5.3.1",
+				"readable-stream": "^3.4.0",
+				"readdir-scoped-modules": "^1.1.0",
 				"request": "^2.88.0",
 				"retry": "^0.12.0",
-				"rimraf": "~2.6.2",
+				"rimraf": "^2.6.3",
 				"safe-buffer": "^5.1.2",
-				"semver": "^5.5.1",
-				"sha": "~2.0.1",
+				"semver": "^5.7.0",
+				"sha": "^3.0.0",
 				"slide": "~1.1.6",
 				"sorted-object": "~2.0.1",
 				"sorted-union-stream": "~2.1.3",
 				"ssri": "^6.0.1",
 				"stringify-package": "^1.0.0",
-				"tar": "^4.4.8",
+				"tar": "^4.4.10",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
 				"uid-number": "0.0.6",
 				"umask": "~1.1.0",
-				"unique-filename": "~1.1.0",
+				"unique-filename": "^1.1.1",
 				"unpipe": "~1.0.0",
 				"update-notifier": "^2.5.0",
 				"uuid": "^3.3.2",
 				"validate-npm-package-license": "^3.0.4",
 				"validate-npm-package-name": "~3.0.0",
 				"which": "^1.3.1",
-				"worker-farm": "^1.6.0",
-				"write-file-atomic": "^2.3.0"
+				"worker-farm": "^1.7.0",
+				"write-file-atomic": "^2.4.3"
 			},
 			"dependencies": {
 				"JSONStream": {
-					"version": "1.3.4",
+					"version": "1.3.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -6649,7 +6712,7 @@
 					"dev": true
 				},
 				"agent-base": {
-					"version": "4.2.0",
+					"version": "4.2.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -6707,7 +6770,7 @@
 					"dev": true
 				},
 				"aproba": {
-					"version": "1.2.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -6723,6 +6786,30 @@
 					"requires": {
 						"delegates": "^1.0.0",
 						"readable-stream": "^2.0.6"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"asap": {
@@ -6784,16 +6871,8 @@
 						"write-file-atomic": "^2.3.0"
 					}
 				},
-				"block-stream": {
-					"version": "0.0.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"inherits": "~2.0.0"
-					}
-				},
 				"bluebird": {
-					"version": "3.5.3",
+					"version": "3.5.5",
 					"bundled": true,
 					"dev": true
 				},
@@ -6825,11 +6904,6 @@
 					"bundled": true,
 					"dev": true
 				},
-				"builtin-modules": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true
-				},
 				"builtins": {
 					"version": "1.0.3",
 					"bundled": true,
@@ -6841,33 +6915,48 @@
 					"dev": true
 				},
 				"byte-size": {
-					"version": "4.0.3",
+					"version": "5.0.1",
 					"bundled": true,
 					"dev": true
 				},
 				"cacache": {
-					"version": "11.2.0",
+					"version": "11.3.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.1",
-						"chownr": "^1.0.1",
-						"figgy-pudding": "^3.1.0",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"lru-cache": "^4.1.3",
+						"bluebird": "^3.5.5",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.1.15",
+						"lru-cache": "^5.1.1",
 						"mississippi": "^3.0.0",
 						"mkdirp": "^0.5.1",
 						"move-concurrently": "^1.0.1",
 						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.2",
-						"ssri": "^6.0.0",
-						"unique-filename": "^1.1.0",
+						"rimraf": "^2.6.3",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
 						"y18n": "^4.0.0"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "7.1.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						}
 					}
 				},
 				"call-limit": {
-					"version": "1.1.0",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -6897,17 +6986,17 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.2",
 					"bundled": true,
 					"dev": true
 				},
 				"ci-info": {
-					"version": "1.6.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"cidr-regex": {
-					"version": "2.0.9",
+					"version": "2.0.10",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -6929,7 +7018,7 @@
 					}
 				},
 				"cli-table3": {
-					"version": "0.5.0",
+					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -7001,7 +7090,7 @@
 					"dev": true
 				},
 				"colors": {
-					"version": "1.1.2",
+					"version": "1.3.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -7037,6 +7126,30 @@
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.2.2",
 						"typedarray": "^0.0.6"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"config-chain": {
@@ -7079,6 +7192,11 @@
 						"run-queue": "^1.0.0"
 					},
 					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
 						"iferr": {
 							"version": "0.1.5",
 							"bundled": true,
@@ -7107,6 +7225,22 @@
 						"lru-cache": "^4.0.1",
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "4.1.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
+							}
+						},
+						"yallist": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"crypto-random-string": {
@@ -7170,6 +7304,14 @@
 						"clone": "^1.0.2"
 					}
 				},
+				"define-properties": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"object-keys": "^1.0.12"
+					}
+				},
 				"delayed-stream": {
 					"version": "1.0.0",
 					"bundled": true,
@@ -7226,6 +7368,30 @@
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.0",
 						"stream-shift": "^1.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"ecc-jsbn": {
@@ -7259,6 +7425,11 @@
 						"once": "^1.4.0"
 					}
 				},
+				"env-paths": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
 				"err-code": {
 					"version": "1.1.2",
 					"bundled": true,
@@ -7272,8 +7443,30 @@
 						"prr": "~1.0.1"
 					}
 				},
+				"es-abstract": {
+					"version": "1.12.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.1.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.1",
+						"is-callable": "^1.1.3",
+						"is-regex": "^1.0.4"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
 				"es6-promise": {
-					"version": "4.2.4",
+					"version": "4.2.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -7302,6 +7495,13 @@
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"extend": {
@@ -7349,6 +7549,30 @@
 					"requires": {
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.4"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"forever-agent": {
@@ -7373,11 +7597,36 @@
 					"requires": {
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"fs-minipass": {
-					"version": "1.2.5",
+					"version": "1.2.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minipass": "^2.2.1"
 					}
@@ -7407,6 +7656,28 @@
 							"version": "0.1.5",
 							"bundled": true,
 							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
 						}
 					}
 				},
@@ -7415,16 +7686,10 @@
 					"bundled": true,
 					"dev": true
 				},
-				"fstream": {
-					"version": "1.0.11",
+				"function-bind": {
+					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"inherits": "~2.0.0",
-						"mkdirp": ">=0.5 0",
-						"rimraf": "2"
-					}
+					"dev": true
 				},
 				"gauge": {
 					"version": "2.7.4",
@@ -7441,6 +7706,11 @@
 						"wide-align": "^1.1.0"
 					},
 					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
@@ -7454,7 +7724,7 @@
 					}
 				},
 				"genfun": {
-					"version": "4.0.1",
+					"version": "5.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -7473,6 +7743,11 @@
 						"slide": "^1.1.6"
 					},
 					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
 						"iferr": {
 							"version": "0.1.5",
 							"bundled": true,
@@ -7486,9 +7761,12 @@
 					"dev": true
 				},
 				"get-stream": {
-					"version": "3.0.0",
+					"version": "4.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
 				},
 				"getpass": {
 					"version": "0.1.7",
@@ -7499,7 +7777,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.3",
+					"version": "7.1.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -7535,10 +7813,17 @@
 						"timed-out": "^4.0.0",
 						"unzip-response": "^2.0.1",
 						"url-parse-lax": "^1.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"graceful-fs": {
-					"version": "4.1.15",
+					"version": "4.2.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -7556,8 +7841,21 @@
 						"har-schema": "^2.0.0"
 					}
 				},
+				"has": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1"
+					}
+				},
 				"has-flag": {
 					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"has-symbols": {
+					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -7653,7 +7951,7 @@
 					}
 				},
 				"inherits": {
-					"version": "2.0.3",
+					"version": "2.0.4",
 					"bundled": true,
 					"dev": true
 				},
@@ -7692,13 +7990,10 @@
 					"bundled": true,
 					"dev": true
 				},
-				"is-builtin-module": {
-					"version": "1.0.0",
+				"is-callable": {
+					"version": "1.1.4",
 					"bundled": true,
-					"dev": true,
-					"requires": {
-						"builtin-modules": "^1.0.0"
-					}
+					"dev": true
 				},
 				"is-ci": {
 					"version": "1.1.0",
@@ -7706,15 +8001,27 @@
 					"dev": true,
 					"requires": {
 						"ci-info": "^1.0.0"
+					},
+					"dependencies": {
+						"ci-info": {
+							"version": "1.6.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"is-cidr": {
-					"version": "2.0.6",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cidr-regex": "^2.0.8"
+						"cidr-regex": "^2.0.10"
 					}
+				},
+				"is-date-object": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
@@ -7756,6 +8063,14 @@
 					"bundled": true,
 					"dev": true
 				},
+				"is-regex": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"has": "^1.0.1"
+					}
+				},
 				"is-retry-allowed": {
 					"version": "1.1.0",
 					"bundled": true,
@@ -7765,6 +8080,14 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"dev": true
+				},
+				"is-symbol": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"has-symbols": "^1.0.0"
+					}
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
@@ -7850,46 +8173,192 @@
 					}
 				},
 				"libcipm": {
-					"version": "2.0.2",
+					"version": "4.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"bin-links": "^1.1.2",
 						"bluebird": "^3.5.1",
+						"figgy-pudding": "^3.5.1",
 						"find-npm-prefix": "^1.0.2",
 						"graceful-fs": "^4.1.11",
+						"ini": "^1.3.5",
 						"lock-verify": "^2.0.2",
 						"mkdirp": "^0.5.1",
-						"npm-lifecycle": "^2.0.3",
+						"npm-lifecycle": "^3.0.0",
 						"npm-logical-tree": "^1.2.1",
 						"npm-package-arg": "^6.1.0",
-						"pacote": "^8.1.6",
-						"protoduck": "^5.0.0",
+						"pacote": "^9.1.0",
 						"read-package-json": "^2.0.13",
 						"rimraf": "^2.6.2",
 						"worker-farm": "^1.6.0"
 					}
 				},
-				"libnpmhook": {
-					"version": "4.0.1",
+				"libnpm": {
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"figgy-pudding": "^3.1.0",
-						"npm-registry-fetch": "^3.0.0"
+						"bin-links": "^1.1.2",
+						"bluebird": "^3.5.3",
+						"find-npm-prefix": "^1.0.2",
+						"libnpmaccess": "^3.0.1",
+						"libnpmconfig": "^1.2.1",
+						"libnpmhook": "^5.0.2",
+						"libnpmorg": "^1.0.0",
+						"libnpmpublish": "^1.1.0",
+						"libnpmsearch": "^2.0.0",
+						"libnpmteam": "^1.0.1",
+						"lock-verify": "^2.0.2",
+						"npm-lifecycle": "^3.0.0",
+						"npm-logical-tree": "^1.2.1",
+						"npm-package-arg": "^6.1.0",
+						"npm-profile": "^4.0.1",
+						"npm-registry-fetch": "^3.8.0",
+						"npmlog": "^4.1.2",
+						"pacote": "^9.2.3",
+						"read-package-json": "^2.0.13",
+						"stringify-package": "^1.0.0"
+					}
+				},
+				"libnpmaccess": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"get-stream": "^4.0.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-registry-fetch": "^3.8.0"
 					},
 					"dependencies": {
-						"npm-registry-fetch": {
-							"version": "3.1.1",
+						"aproba": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"libnpmconfig": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"find-up": "^3.0.0",
+						"ini": "^1.3.5"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "3.0.0",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"bluebird": "^3.5.1",
-								"figgy-pudding": "^3.1.0",
-								"lru-cache": "^4.1.2",
-								"make-fetch-happen": "^4.0.0",
-								"npm-package-arg": "^6.0.0"
+								"locate-path": "^3.0.0"
 							}
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "2.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-try": "^2.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"p-try": {
+							"version": "2.2.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"libnpmhook": {
+					"version": "5.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^3.8.0"
+					}
+				},
+				"libnpmorg": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^3.8.0"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"libnpmpublish": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.0.0",
+						"lodash.clonedeep": "^4.5.0",
+						"normalize-package-data": "^2.4.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-registry-fetch": "^3.8.0",
+						"semver": "^5.5.1",
+						"ssri": "^6.0.1"
+					}
+				},
+				"libnpmsearch": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^3.8.0"
+					}
+				},
+				"libnpmteam": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^3.8.0"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
@@ -7918,11 +8387,11 @@
 					}
 				},
 				"lock-verify": {
-					"version": "2.0.2",
+					"version": "2.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"npm-package-arg": "^5.1.2 || 6",
+						"npm-package-arg": "^6.1.0",
 						"semver": "^5.4.1"
 					}
 				},
@@ -8012,12 +8481,11 @@
 					"dev": true
 				},
 				"lru-cache": {
-					"version": "4.1.3",
+					"version": "5.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
+						"yallist": "^3.0.2"
 					}
 				},
 				"make-dir": {
@@ -8029,16 +8497,16 @@
 					}
 				},
 				"make-fetch-happen": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"agentkeepalive": "^3.4.1",
-						"cacache": "^11.0.1",
+						"cacache": "^11.3.3",
 						"http-cache-semantics": "^3.8.1",
 						"http-proxy-agent": "^2.1.0",
 						"https-proxy-agent": "^2.2.1",
-						"lru-cache": "^4.1.2",
+						"lru-cache": "^5.1.1",
 						"mississippi": "^3.0.0",
 						"node-fetch-npm": "^2.0.2",
 						"promise-retry": "^1.1.1",
@@ -8093,6 +8561,7 @@
 				"minipass": {
 					"version": "2.3.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -8100,13 +8569,15 @@
 					"dependencies": {
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"minizlib": {
-					"version": "1.1.1",
+					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minipass": "^2.2.1"
 					}
@@ -8147,6 +8618,13 @@
 						"mkdirp": "^0.5.1",
 						"rimraf": "^2.5.4",
 						"run-queue": "^1.0.3"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"ms": {
@@ -8170,21 +8648,20 @@
 					}
 				},
 				"node-gyp": {
-					"version": "3.8.0",
+					"version": "5.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fstream": "^1.0.0",
+						"env-paths": "^1.0.0",
 						"glob": "^7.0.3",
 						"graceful-fs": "^4.1.2",
 						"mkdirp": "^0.5.0",
 						"nopt": "2 || 3",
 						"npmlog": "0 || 1 || 2 || 3 || 4",
-						"osenv": "0",
 						"request": "^2.87.0",
 						"rimraf": "2",
 						"semver": "~5.3.0",
-						"tar": "^2.0.0",
+						"tar": "^4.4.8",
 						"which": "1"
 					},
 					"dependencies": {
@@ -8200,31 +8677,6 @@
 							"version": "5.3.0",
 							"bundled": true,
 							"dev": true
-						},
-						"tar": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-							"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-							"dev": true,
-							"requires": {
-								"block-stream": "*",
-								"fstream": "^1.0.12",
-								"inherits": "2"
-							},
-							"dependencies": {
-								"fstream": {
-									"version": "1.0.12",
-									"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-									"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-									"dev": true,
-									"requires": {
-										"graceful-fs": "^4.1.2",
-										"inherits": "~2.0.0",
-										"mkdirp": ">=0.5 0",
-										"rimraf": "2"
-									}
-								}
-							}
 						}
 					}
 				},
@@ -8238,18 +8690,28 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "2.4.0",
+					"version": "2.5.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
-						"is-builtin-module": "^1.0.0",
+						"resolve": "^1.10.0",
 						"semver": "2 || 3 || 4 || 5",
 						"validate-npm-package-license": "^3.0.1"
+					},
+					"dependencies": {
+						"resolve": {
+							"version": "1.10.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-parse": "^1.0.6"
+							}
+						}
 					}
 				},
 				"npm-audit-report": {
-					"version": "1.3.1",
+					"version": "1.3.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8258,7 +8720,7 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.5",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -8276,13 +8738,13 @@
 					}
 				},
 				"npm-lifecycle": {
-					"version": "2.1.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"byline": "^5.0.0",
-						"graceful-fs": "^4.1.11",
-						"node-gyp": "^3.8.0",
+						"graceful-fs": "^4.1.15",
+						"node-gyp": "^5.0.2",
 						"resolve-from": "^4.0.0",
 						"slide": "^1.1.6",
 						"uid-number": "0.0.6",
@@ -8307,7 +8769,7 @@
 					}
 				},
 				"npm-packlist": {
-					"version": "1.1.12",
+					"version": "1.4.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8316,170 +8778,54 @@
 					}
 				},
 				"npm-pick-manifest": {
-					"version": "2.1.0",
+					"version": "2.2.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
+						"figgy-pudding": "^3.5.1",
 						"npm-package-arg": "^6.0.0",
 						"semver": "^5.4.1"
 					}
 				},
 				"npm-profile": {
-					"version": "3.0.2",
+					"version": "4.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2 || 2",
-						"make-fetch-happen": "^2.5.0 || 3 || 4"
-					}
-				},
-				"npm-registry-client": {
-					"version": "8.6.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"concat-stream": "^1.5.2",
-						"graceful-fs": "^4.1.6",
-						"normalize-package-data": "~1.0.1 || ^2.0.0",
-						"npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-						"npmlog": "2 || ^3.1.0 || ^4.0.0",
-						"once": "^1.3.3",
-						"request": "^2.74.0",
-						"retry": "^0.10.0",
-						"safe-buffer": "^5.1.1",
-						"semver": "2 >=2.2.1 || 3.x || 4 || 5",
-						"slide": "^1.1.3",
-						"ssri": "^5.2.4"
-					},
-					"dependencies": {
-						"retry": {
-							"version": "0.10.1",
-							"bundled": true,
-							"dev": true
-						},
-						"ssri": {
-							"version": "5.3.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"safe-buffer": "^5.1.1"
-							}
-						}
+						"figgy-pudding": "^3.4.1",
+						"npm-registry-fetch": "^3.8.0"
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "1.1.0",
+					"version": "3.9.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
+						"JSONStream": "^1.3.4",
 						"bluebird": "^3.5.1",
-						"figgy-pudding": "^2.0.1",
-						"lru-cache": "^4.1.2",
-						"make-fetch-happen": "^3.0.0",
-						"npm-package-arg": "^6.0.0",
-						"safe-buffer": "^5.1.1"
+						"figgy-pudding": "^3.4.1",
+						"lru-cache": "^5.1.1",
+						"make-fetch-happen": "^4.0.2",
+						"npm-package-arg": "^6.1.0"
 					},
 					"dependencies": {
-						"cacache": {
-							"version": "10.0.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"bluebird": "^3.5.1",
-								"chownr": "^1.0.1",
-								"glob": "^7.1.2",
-								"graceful-fs": "^4.1.11",
-								"lru-cache": "^4.1.1",
-								"mississippi": "^2.0.0",
-								"mkdirp": "^0.5.1",
-								"move-concurrently": "^1.0.1",
-								"promise-inflight": "^1.0.1",
-								"rimraf": "^2.6.2",
-								"ssri": "^5.2.4",
-								"unique-filename": "^1.1.0",
-								"y18n": "^4.0.0"
-							},
-							"dependencies": {
-								"mississippi": {
-									"version": "2.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"concat-stream": "^1.5.0",
-										"duplexify": "^3.4.2",
-										"end-of-stream": "^1.1.0",
-										"flush-write-stream": "^1.0.0",
-										"from2": "^2.1.0",
-										"parallel-transform": "^1.1.0",
-										"pump": "^2.0.1",
-										"pumpify": "^1.3.3",
-										"stream-each": "^1.1.0",
-										"through2": "^2.0.0"
-									}
-								}
-							}
-						},
-						"figgy-pudding": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true
-						},
 						"make-fetch-happen": {
-							"version": "3.0.0",
+							"version": "4.0.2",
 							"bundled": true,
 							"dev": true,
 							"requires": {
 								"agentkeepalive": "^3.4.1",
-								"cacache": "^10.0.4",
+								"cacache": "^11.3.3",
 								"http-cache-semantics": "^3.8.1",
 								"http-proxy-agent": "^2.1.0",
-								"https-proxy-agent": "^2.2.0",
-								"lru-cache": "^4.1.2",
+								"https-proxy-agent": "^2.2.1",
+								"lru-cache": "^5.1.1",
 								"mississippi": "^3.0.0",
 								"node-fetch-npm": "^2.0.2",
 								"promise-retry": "^1.1.1",
-								"socks-proxy-agent": "^3.0.1",
-								"ssri": "^5.2.4"
-							}
-						},
-						"pump": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"end-of-stream": "^1.1.0",
-								"once": "^1.3.1"
-							}
-						},
-						"smart-buffer": {
-							"version": "1.1.15",
-							"bundled": true,
-							"dev": true
-						},
-						"socks": {
-							"version": "1.1.10",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ip": "^1.1.4",
-								"smart-buffer": "^1.0.13"
-							}
-						},
-						"socks-proxy-agent": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"agent-base": "^4.1.0",
-								"socks": "^1.1.10"
-							}
-						},
-						"ssri": {
-							"version": "5.3.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"safe-buffer": "^5.1.1"
+								"socks-proxy-agent": "^4.0.0",
+								"ssri": "^6.0.0"
 							}
 						}
 					}
@@ -8522,6 +8868,20 @@
 					"version": "4.1.1",
 					"bundled": true,
 					"dev": true
+				},
+				"object-keys": {
+					"version": "1.0.12",
+					"bundled": true,
+					"dev": true
+				},
+				"object.getownpropertydescriptors": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.2",
+						"es-abstract": "^1.5.1"
+					}
 				},
 				"once": {
 					"version": "1.4.0",
@@ -8603,35 +8963,48 @@
 					}
 				},
 				"pacote": {
-					"version": "8.1.6",
+					"version": "9.5.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.1",
-						"cacache": "^11.0.2",
-						"get-stream": "^3.0.0",
-						"glob": "^7.1.2",
-						"lru-cache": "^4.1.3",
+						"bluebird": "^3.5.3",
+						"cacache": "^11.3.2",
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.1.0",
+						"glob": "^7.1.3",
+						"lru-cache": "^5.1.1",
 						"make-fetch-happen": "^4.0.1",
 						"minimatch": "^3.0.4",
-						"minipass": "^2.3.3",
+						"minipass": "^2.3.5",
 						"mississippi": "^3.0.0",
 						"mkdirp": "^0.5.1",
 						"normalize-package-data": "^2.4.0",
 						"npm-package-arg": "^6.1.0",
-						"npm-packlist": "^1.1.10",
-						"npm-pick-manifest": "^2.1.0",
+						"npm-packlist": "^1.1.12",
+						"npm-pick-manifest": "^2.2.3",
+						"npm-registry-fetch": "^3.8.0",
 						"osenv": "^0.1.5",
 						"promise-inflight": "^1.0.1",
 						"promise-retry": "^1.1.1",
-						"protoduck": "^5.0.0",
+						"protoduck": "^5.0.1",
 						"rimraf": "^2.6.2",
 						"safe-buffer": "^5.1.2",
-						"semver": "^5.5.0",
-						"ssri": "^6.0.0",
-						"tar": "^4.4.3",
-						"unique-filename": "^1.1.0",
-						"which": "^1.3.0"
+						"semver": "^5.6.0",
+						"ssri": "^6.0.1",
+						"tar": "^4.4.8",
+						"unique-filename": "^1.1.1",
+						"which": "^1.3.1"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						}
 					}
 				},
 				"parallel-transform": {
@@ -8642,6 +9015,30 @@
 						"cyclist": "~0.2.2",
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.1.5"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"path-exists": {
@@ -8661,6 +9058,11 @@
 				},
 				"path-key": {
 					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -8719,11 +9121,11 @@
 					"dev": true
 				},
 				"protoduck": {
-					"version": "5.0.0",
+					"version": "5.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"genfun": "^4.0.1"
+						"genfun": "^5.0.0"
 					}
 				},
 				"prr": {
@@ -8787,11 +9189,12 @@
 					"dev": true
 				},
 				"query-string": {
-					"version": "6.1.0",
+					"version": "6.8.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"decode-uri-component": "^0.2.0",
+						"split-on-first": "^1.0.0",
 						"strict-uri-encode": "^2.0.0"
 					}
 				},
@@ -8861,33 +9264,27 @@
 					}
 				},
 				"read-package-tree": {
-					"version": "5.2.1",
+					"version": "5.3.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debuglog": "^1.0.1",
-						"dezalgo": "^1.0.0",
-						"once": "^1.3.0",
 						"read-package-json": "^2.0.0",
-						"readdir-scoped-modules": "^1.0.0"
+						"readdir-scoped-modules": "^1.0.0",
+						"util-promisify": "^2.1.0"
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.6",
+					"version": "3.4.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				},
 				"readdir-scoped-modules": {
-					"version": "1.0.2",
+					"version": "1.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8962,11 +9359,11 @@
 					"dev": true
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"run-queue": {
@@ -8975,11 +9372,19 @@
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -8987,7 +9392,7 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "5.5.1",
+					"version": "5.7.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -9005,12 +9410,11 @@
 					"dev": true
 				},
 				"sha": {
-					"version": "2.0.1",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"readable-stream": "^2.0.2"
+						"graceful-fs": "^4.1.2"
 					}
 				},
 				"shebang-command": {
@@ -9134,7 +9538,12 @@
 					}
 				},
 				"spdx-license-ids": {
-					"version": "3.0.0",
+					"version": "3.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"split-on-first": {
+					"version": "1.1.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -9178,6 +9587,30 @@
 					"requires": {
 						"readable-stream": "^2.1.5",
 						"stream-shift": "^1.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"stream-shift": {
@@ -9220,7 +9653,7 @@
 					}
 				},
 				"string_decoder": {
-					"version": "1.1.1",
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -9258,6 +9691,36 @@
 						"has-flag": "^3.0.0"
 					}
 				},
+				"tar": {
+					"version": "4.4.10",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.3.5",
+						"minizlib": "^1.2.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.3"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
 				"term-size": {
 					"version": "1.2.0",
 					"bundled": true,
@@ -9283,6 +9746,30 @@
 					"requires": {
 						"readable-stream": "^2.1.5",
 						"xtend": "~4.0.1"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"timed-out": {
@@ -9334,7 +9821,7 @@
 					"dev": true
 				},
 				"unique-filename": {
-					"version": "1.1.0",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -9401,6 +9888,14 @@
 					"version": "1.0.3",
 					"bundled": true,
 					"dev": true
+				},
+				"util-promisify": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"object.getownpropertydescriptors": "^2.0.3"
+					}
 				},
 				"uuid": {
 					"version": "3.3.2",
@@ -9484,7 +9979,7 @@
 					}
 				},
 				"worker-farm": {
-					"version": "1.6.0",
+					"version": "1.7.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -9518,7 +10013,7 @@
 					"dev": true
 				},
 				"write-file-atomic": {
-					"version": "2.3.0",
+					"version": "2.4.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -9543,7 +10038,7 @@
 					"dev": true
 				},
 				"yallist": {
-					"version": "2.1.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true
 				},
@@ -10267,12 +10762,12 @@
 			}
 		},
 		"registry-auth-token": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-			"integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+			"integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
 			"dev": true,
 			"requires": {
-				"rc": "^1.1.6",
+				"rc": "^1.2.8",
 				"safe-buffer": "^5.0.1"
 			}
 		},
@@ -10629,9 +11124,9 @@
 			"dev": true
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -11056,6 +11551,12 @@
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
+		"strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true
+		},
 		"strip-indent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
@@ -11106,6 +11607,7 @@
 			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
 			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"fs-minipass": "^1.2.5",
@@ -11120,7 +11622,8 @@
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -11435,6 +11938,12 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
+		"type-fest": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+			"dev": true
+		},
 		"typescript": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
@@ -11462,38 +11971,15 @@
 			}
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
 		"commit": "git-cz"
 	},
 	"dependencies": {
-		"@types/lodash": "^4.14.123",
-		"@types/semver": "^6.0.0",
 		"detect-indent": "^6.0.0",
 		"detect-newline": "^3.0.0",
 		"fs-extra": "^8.0.0",
@@ -46,7 +44,9 @@
 		"@types/detect-indent": "^5.0.0",
 		"@types/fs-extra": "^7.0.0",
 		"@types/jest": "^24.0.11",
+		"@types/lodash": "^4.14.123",
 		"@types/node": "^12.0.2",
+		"@types/semver": "^6.0.0",
 		"codecov": "^3.3.0",
 		"jest": "^24.7.1",
 		"ts-jest": "^24.0.2",


### PR DESCRIPTION
### Linked issue
Types are not required when using this library, it's only for local development.
