### PR TITLE
pipeline: test on latest node range 10, 12, and 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
 language: node_js
 node_js:
-  - 12
   - 10
-  - 8
+  - 12
+  - 13
 cache:
   directories:
     - ~/.npm


### PR DESCRIPTION
### Linked issue
Maintenance change, [Node 8 is EOL](https://nodejs.org/en/about/releases/)
