### PR TITLE
fix: use semver constructor to create template variables to support prereleases

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -21,7 +21,7 @@ export const getVersionCode = (next: SemVer, expo: SemVer) => (
 export const getDefaultVariables = (meta: ManifestMeta, context: Context) => {
 	const expo = coerce(meta.manifest.sdkVersion);
 	const last = coerce(context.lastRelease!.version);
-	const next = coerce(context.nextRelease!.version);
+	const next = new SemVer(context.nextRelease!.version, {includePrerelease: true}); // coerce truncates prerelease tags
 
 	return {
 		code: (next && expo) ? getVersionCode(next, expo) : '000000000',


### PR DESCRIPTION
### Linked issue
Solves issue  #185

### Additional context
Using coerce() when building 'next' and 'last' template variables truncates all prerelease information contained in the version string turning all prerelease related SemVer fields useless when using those variables.

The suggested change only affects 'next' template variable construction (the only one I need) Please consider extending it to last if you find it usefull.

