### PR TITLE
fix: use semver constructor to create template variables supporting p…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.0.0"
+				"@babel/highlight": "7.5.0"
 			}
 		},
 		"@babel/core": {
@@ -19,20 +19,20 @@
 			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
-				"convert-source-map": "^1.1.0",
-				"debug": "^4.1.0",
-				"json5": "^2.1.0",
-				"lodash": "^4.17.13",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
+				"@babel/code-frame": "7.5.5",
+				"@babel/generator": "7.5.5",
+				"@babel/helpers": "7.5.5",
+				"@babel/parser": "7.5.5",
+				"@babel/template": "7.4.4",
+				"@babel/traverse": "7.5.5",
+				"@babel/types": "7.5.5",
+				"convert-source-map": "1.6.0",
+				"debug": "4.1.1",
+				"json5": "2.1.0",
+				"lodash": "4.17.15",
+				"resolve": "1.11.1",
+				"semver": "5.7.1",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"debug": {
@@ -41,7 +41,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -64,11 +64,11 @@
 			"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.5.5",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"@babel/types": "7.5.5",
+				"jsesc": "2.5.2",
+				"lodash": "4.17.15",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			}
 		},
 		"@babel/helper-function-name": {
@@ -77,9 +77,9 @@
 			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.0.0",
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-get-function-arity": "7.0.0",
+				"@babel/template": "7.4.4",
+				"@babel/types": "7.5.5"
 			}
 		},
 		"@babel/helper-get-function-arity": {
@@ -88,7 +88,7 @@
 			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "7.5.5"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -103,7 +103,7 @@
 			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4"
+				"@babel/types": "7.5.5"
 			}
 		},
 		"@babel/helpers": {
@@ -112,9 +112,9 @@
 			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/template": "7.4.4",
+				"@babel/traverse": "7.5.5",
+				"@babel/types": "7.5.5"
 			}
 		},
 		"@babel/highlight": {
@@ -123,9 +123,9 @@
 			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^4.0.0"
+				"chalk": "2.3.1",
+				"esutils": "2.0.2",
+				"js-tokens": "4.0.0"
 			}
 		},
 		"@babel/parser": {
@@ -140,7 +140,7 @@
 			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/template": {
@@ -149,9 +149,9 @@
 			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/code-frame": "7.5.5",
+				"@babel/parser": "7.5.5",
+				"@babel/types": "7.5.5"
 			}
 		},
 		"@babel/traverse": {
@@ -160,15 +160,15 @@
 			"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.5.5",
-				"@babel/types": "^7.5.5",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
+				"@babel/code-frame": "7.5.5",
+				"@babel/generator": "7.5.5",
+				"@babel/helper-function-name": "7.1.0",
+				"@babel/helper-split-export-declaration": "7.4.4",
+				"@babel/parser": "7.5.5",
+				"@babel/types": "7.5.5",
+				"debug": "4.1.1",
+				"globals": "11.12.0",
+				"lodash": "4.17.15"
 			},
 			"dependencies": {
 				"debug": {
@@ -177,7 +177,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -194,9 +194,9 @@
 			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.13",
-				"to-fast-properties": "^2.0.0"
+				"esutils": "2.0.2",
+				"lodash": "4.17.15",
+				"to-fast-properties": "2.0.0"
 			}
 		},
 		"@cnakazawa/watch": {
@@ -205,8 +205,8 @@
 			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
 			"dev": true,
 			"requires": {
-				"exec-sh": "^0.3.2",
-				"minimist": "^1.2.0"
+				"exec-sh": "0.3.2",
+				"minimist": "1.2.0"
 			}
 		},
 		"@commitlint/cli": {
@@ -215,10 +215,10 @@
 			"integrity": "sha512-8fJ5pmytc38yw2QWbTTJmXLfSiWPwMkHH4govo9zJ/+ERPBF2jvlxD/dQvk24ezcizjKc6LFka2edYC4OQ+Dgw==",
 			"dev": true,
 			"requires": {
-				"@commitlint/format": "^8.2.0",
-				"@commitlint/lint": "^8.2.0",
-				"@commitlint/load": "^8.2.0",
-				"@commitlint/read": "^8.2.0",
+				"@commitlint/format": "8.2.0",
+				"@commitlint/lint": "8.2.0",
+				"@commitlint/load": "8.2.0",
+				"@commitlint/read": "8.2.0",
 				"babel-polyfill": "6.26.0",
 				"chalk": "2.4.2",
 				"get-stdin": "7.0.0",
@@ -249,7 +249,7 @@
 					"integrity": "sha512-sA77agkDEMsEMrlGhrLtAg8vRexkOofEEv/CZX+4xlANyAz2kNwJvMg33lcL65CBhqKEnRRJRxfZ1ZqcujdKcQ==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.0.1"
+						"chalk": "2.4.2"
 					}
 				},
 				"@commitlint/is-ignored": {
@@ -258,7 +258,7 @@
 					"integrity": "sha512-ADaGnKfbfV6KD1pETp0Qf7XAyc75xTy3WJlbvPbwZ4oPdBMsXF0oXEEGMis6qABfU2IXan5/KAJgAFX3vdd0jA==",
 					"dev": true,
 					"requires": {
-						"@types/semver": "^6.0.1",
+						"@types/semver": "6.2.0",
 						"semver": "6.2.0"
 					}
 				},
@@ -268,10 +268,10 @@
 					"integrity": "sha512-ch9JN8aR37ufdjoWv50jLfvFz9rWMgLW5HEkMGLsM/51gjekmQYS5NJg8S2+6F5+jmralAO7VkUMI6FukXKX0A==",
 					"dev": true,
 					"requires": {
-						"@commitlint/is-ignored": "^8.2.0",
-						"@commitlint/parse": "^8.2.0",
-						"@commitlint/rules": "^8.2.0",
-						"babel-runtime": "^6.23.0",
+						"@commitlint/is-ignored": "8.2.0",
+						"@commitlint/parse": "8.2.0",
+						"@commitlint/rules": "8.2.0",
+						"babel-runtime": "6.26.0",
 						"lodash": "4.17.14"
 					}
 				},
@@ -281,13 +281,13 @@
 					"integrity": "sha512-EV6PfAY/p83QynNd1llHxJiNxKmp43g8+7dZbyfHFbsGOdokrCnoelAVZ+WGgktXwLN/uXyfkcIAxwac015UYw==",
 					"dev": true,
 					"requires": {
-						"@commitlint/execute-rule": "^8.2.0",
-						"@commitlint/resolve-extends": "^8.2.0",
-						"babel-runtime": "^6.23.0",
+						"@commitlint/execute-rule": "8.2.0",
+						"@commitlint/resolve-extends": "8.2.0",
+						"babel-runtime": "6.26.0",
 						"chalk": "2.4.2",
-						"cosmiconfig": "^5.2.0",
+						"cosmiconfig": "5.2.1",
 						"lodash": "4.17.14",
-						"resolve-from": "^5.0.0"
+						"resolve-from": "5.0.0"
 					}
 				},
 				"@commitlint/message": {
@@ -302,9 +302,9 @@
 					"integrity": "sha512-vzouqroTXG6QXApkrps0gbeSYW6w5drpUk7QAeZIcaCSPsQXDM8eqqt98ZzlzLJHo5oPNXPX1AAVSTrssvHemA==",
 					"dev": true,
 					"requires": {
-						"conventional-changelog-angular": "^1.3.3",
-						"conventional-commits-parser": "^2.1.0",
-						"lodash": "^4.17.11"
+						"conventional-changelog-angular": "1.6.6",
+						"conventional-commits-parser": "2.1.7",
+						"lodash": "4.17.14"
 					}
 				},
 				"@commitlint/read": {
@@ -313,10 +313,10 @@
 					"integrity": "sha512-1tBai1VuSQmsOTsvJr3Fi/GZqX3zdxRqYe/yN4i3cLA5S2Y4QGJ5I3l6nGZlKgm/sSelTCVKHltrfWU8s5H7SA==",
 					"dev": true,
 					"requires": {
-						"@commitlint/top-level": "^8.2.0",
-						"@marionebl/sander": "^0.6.0",
-						"babel-runtime": "^6.23.0",
-						"git-raw-commits": "^1.3.0"
+						"@commitlint/top-level": "8.2.0",
+						"@marionebl/sander": "0.6.1",
+						"babel-runtime": "6.26.0",
+						"git-raw-commits": "1.3.6"
 					}
 				},
 				"@commitlint/resolve-extends": {
@@ -325,11 +325,11 @@
 					"integrity": "sha512-cwi0HUsDcD502HBP8huXfTkVuWmeo1Fiz3GKxNwMBBsJV4+bKa7QrtxbNpXhVuarX7QjWfNTvmW6KmFS7YK9uw==",
 					"dev": true,
 					"requires": {
-						"@types/node": "^12.0.2",
-						"import-fresh": "^3.0.0",
+						"@types/node": "12.12.22",
+						"import-fresh": "3.1.0",
 						"lodash": "4.17.14",
-						"resolve-from": "^5.0.0",
-						"resolve-global": "^1.0.0"
+						"resolve-from": "5.0.0",
+						"resolve-global": "1.0.0"
 					},
 					"dependencies": {
 						"@types/node": {
@@ -346,10 +346,10 @@
 					"integrity": "sha512-FlqSBBP2Gxt5Ibw+bxdYpzqYR6HI8NIBpaTBhAjSEAduQtdWFMOhF0zsgkwH7lHN7opaLcnY2fXxAhbzTmJQQA==",
 					"dev": true,
 					"requires": {
-						"@commitlint/ensure": "^8.2.0",
-						"@commitlint/message": "^8.2.0",
-						"@commitlint/to-lines": "^8.2.0",
-						"babel-runtime": "^6.23.0"
+						"@commitlint/ensure": "8.2.0",
+						"@commitlint/message": "8.2.0",
+						"@commitlint/to-lines": "8.2.0",
+						"babel-runtime": "6.26.0"
 					}
 				},
 				"@commitlint/to-lines": {
@@ -364,7 +364,7 @@
 					"integrity": "sha512-Yaw4KmYNy31/HhRUuZ+fupFcDalnfpdu4JGBgGAqS9aBHdMSSWdWqtAaDaxdtWjTZeN3O0sA2gOhXwvKwiDwvw==",
 					"dev": true,
 					"requires": {
-						"find-up": "^4.0.0"
+						"find-up": "4.1.0"
 					}
 				},
 				"chalk": {
@@ -373,9 +373,9 @@
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"find-up": {
@@ -384,8 +384,8 @@
 					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
+						"locate-path": "5.0.0",
+						"path-exists": "4.0.0"
 					}
 				},
 				"locate-path": {
@@ -394,7 +394,7 @@
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^4.1.0"
+						"p-locate": "4.1.0"
 					}
 				},
 				"lodash": {
@@ -409,7 +409,7 @@
 					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"p-try": "2.2.0"
 					}
 				},
 				"p-locate": {
@@ -418,7 +418,7 @@
 					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.2.0"
+						"p-limit": "2.2.1"
 					}
 				},
 				"p-try": {
@@ -476,7 +476,7 @@
 			"integrity": "sha512-D0cmabUTQIKdABgt08d9JAvO9+lMRAmkcsZx8TMScY502R67HCw77JhzRDcw1RmqX5rN8JO6ZjDHO92Pbwlt+Q==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "2.3.1"
 			}
 		},
 		"@commitlint/is-ignored": {
@@ -485,7 +485,7 @@
 			"integrity": "sha512-HUSxx6kuLbqrQ8jb5QRzo+yR+CIXgA9HNcIcZ1qWrb+O9GOixt3mlW8li1IcfIgfODlaWoxIz0jYCxR08IoQLg==",
 			"dev": true,
 			"requires": {
-				"@types/semver": "^6.0.1",
+				"@types/semver": "6.2.0",
 				"semver": "6.1.1"
 			},
 			"dependencies": {
@@ -503,10 +503,10 @@
 			"integrity": "sha512-WYjbUgtqvnlVH3S3XPZMAa+N7KO0yQ+GuUG20Qra+EtER6SRYawykmEs4wAyrmY8VcFXUnKgSlIQUsqmGKwNZQ==",
 			"dev": true,
 			"requires": {
-				"@commitlint/is-ignored": "^8.1.0",
-				"@commitlint/parse": "^8.1.0",
-				"@commitlint/rules": "^8.1.0",
-				"babel-runtime": "^6.23.0",
+				"@commitlint/is-ignored": "8.1.0",
+				"@commitlint/parse": "8.1.0",
+				"@commitlint/rules": "8.1.0",
+				"babel-runtime": "6.26.0",
 				"lodash": "4.17.14"
 			},
 			"dependencies": {
@@ -524,13 +524,13 @@
 			"integrity": "sha512-ra02Dvmd7Gp1+uFLzTY3yGOpHjPzl5T9wYg/xrtPJNiOWXvQ0Mw7THw+ucd1M5iLUWjvdavv2N87YDRc428wHg==",
 			"dev": true,
 			"requires": {
-				"@commitlint/execute-rule": "^8.1.0",
-				"@commitlint/resolve-extends": "^8.1.0",
-				"babel-runtime": "^6.23.0",
+				"@commitlint/execute-rule": "8.1.0",
+				"@commitlint/resolve-extends": "8.1.0",
+				"babel-runtime": "6.26.0",
 				"chalk": "2.4.2",
-				"cosmiconfig": "^5.2.0",
+				"cosmiconfig": "5.2.1",
 				"lodash": "4.17.14",
-				"resolve-from": "^5.0.0"
+				"resolve-from": "5.0.0"
 			},
 			"dependencies": {
 				"chalk": {
@@ -539,9 +539,9 @@
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"lodash": {
@@ -564,9 +564,9 @@
 			"integrity": "sha512-n4fEbZ5kdK5HChvne7Mj8rGGkKMfA4H11IuWiWmmMzgmZTNb/B04LPrzdUm4lm3f10XzM2JMM7PLXqofQJOGvA==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-angular": "^1.3.3",
-				"conventional-commits-parser": "^2.1.0",
-				"lodash": "^4.17.11"
+				"conventional-changelog-angular": "1.6.6",
+				"conventional-commits-parser": "2.1.7",
+				"lodash": "4.17.15"
 			}
 		},
 		"@commitlint/read": {
@@ -575,10 +575,10 @@
 			"integrity": "sha512-PKsGMQFEr2sX/+orI71b82iyi8xFqb7F4cTvsLxzB5x6/QutxPVM3rg+tEVdi6rBKIDuqRIp2puDZQuREZs3vg==",
 			"dev": true,
 			"requires": {
-				"@commitlint/top-level": "^8.1.0",
-				"@marionebl/sander": "^0.6.0",
-				"babel-runtime": "^6.23.0",
-				"git-raw-commits": "^1.3.0"
+				"@commitlint/top-level": "8.1.0",
+				"@marionebl/sander": "0.6.1",
+				"babel-runtime": "6.26.0",
+				"git-raw-commits": "1.3.6"
 			}
 		},
 		"@commitlint/resolve-extends": {
@@ -587,11 +587,11 @@
 			"integrity": "sha512-r/y+CeKW72Oa9BUctS1+I/MFCDiI3lfhwfQ65Tpfn6eZ4CuBYKzrCRi++GTHeAFKE3y8q1epJq5Rl/1GBejtBw==",
 			"dev": true,
 			"requires": {
-				"@types/node": "^12.0.2",
-				"import-fresh": "^3.0.0",
+				"@types/node": "12.12.22",
+				"import-fresh": "3.1.0",
 				"lodash": "4.17.14",
-				"resolve-from": "^5.0.0",
-				"resolve-global": "^1.0.0"
+				"resolve-from": "5.0.0",
+				"resolve-global": "1.0.0"
 			},
 			"dependencies": {
 				"@types/node": {
@@ -614,10 +614,10 @@
 			"integrity": "sha512-hlM8VfNjsOkbvMteFyqn0c3akiUjqG09Iid28MBLrXl/d+8BR3eTzwJ4wMta4oz/iqGyrIywvg1FpHrV977MPA==",
 			"dev": true,
 			"requires": {
-				"@commitlint/ensure": "^8.1.0",
-				"@commitlint/message": "^8.1.0",
-				"@commitlint/to-lines": "^8.1.0",
-				"babel-runtime": "^6.23.0"
+				"@commitlint/ensure": "8.1.0",
+				"@commitlint/message": "8.1.0",
+				"@commitlint/to-lines": "8.1.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"@commitlint/to-lines": {
@@ -632,7 +632,7 @@
 			"integrity": "sha512-EvQuofuA/+0l1w9pkG/PRyIwACmZdIh9qxyax7w7mR8qqmSHscqf2jARIylh1TOx0uI9egO8MuPLiwC1RwyREA==",
 			"dev": true,
 			"requires": {
-				"find-up": "^4.0.0"
+				"find-up": "4.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -641,8 +641,8 @@
 					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
+						"locate-path": "5.0.0",
+						"path-exists": "4.0.0"
 					}
 				},
 				"locate-path": {
@@ -651,7 +651,7 @@
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^4.1.0"
+						"p-locate": "4.1.0"
 					}
 				},
 				"p-limit": {
@@ -660,7 +660,7 @@
 					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"p-try": "2.2.0"
 					}
 				},
 				"p-locate": {
@@ -669,7 +669,7 @@
 					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.2.0"
+						"p-limit": "2.2.0"
 					}
 				},
 				"p-try": {
@@ -692,7 +692,7 @@
 			"integrity": "sha512-SXZh9qpAWwvzW2KlG5HOxnci1KMkUZOqr2wKMzgXuV+BS5jhkZaPsKvrrs85FZtUWdJuqFNHTVXKoetgWgMXpQ==",
 			"dev": true,
 			"requires": {
-				"@commitlint/cli": "^8.2.0",
+				"@commitlint/cli": "8.2.0",
 				"babel-runtime": "6.26.0",
 				"execa": "0.11.0"
 			}
@@ -703,9 +703,9 @@
 			"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
 			"dev": true,
 			"requires": {
-				"@jest/source-map": "^24.9.0",
-				"chalk": "^2.0.1",
-				"slash": "^2.0.0"
+				"@jest/source-map": "24.9.0",
+				"chalk": "2.3.1",
+				"slash": "2.0.0"
 			},
 			"dependencies": {
 				"slash": {
@@ -722,34 +722,34 @@
 			"integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/reporters": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.15",
-				"jest-changed-files": "^24.9.0",
-				"jest-config": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-resolve-dependencies": "^24.9.0",
-				"jest-runner": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"jest-watcher": "^24.9.0",
-				"micromatch": "^3.1.10",
-				"p-each-series": "^1.0.0",
-				"realpath-native": "^1.1.0",
-				"rimraf": "^2.5.4",
-				"slash": "^2.0.0",
-				"strip-ansi": "^5.0.0"
+				"@jest/console": "24.9.0",
+				"@jest/reporters": "24.9.0",
+				"@jest/test-result": "24.9.0",
+				"@jest/transform": "24.9.0",
+				"@jest/types": "24.9.0",
+				"ansi-escapes": "3.2.0",
+				"chalk": "2.3.1",
+				"exit": "0.1.2",
+				"graceful-fs": "4.2.0",
+				"jest-changed-files": "24.9.0",
+				"jest-config": "24.9.0",
+				"jest-haste-map": "24.9.0",
+				"jest-message-util": "24.9.0",
+				"jest-regex-util": "24.9.0",
+				"jest-resolve": "24.9.0",
+				"jest-resolve-dependencies": "24.9.0",
+				"jest-runner": "24.9.0",
+				"jest-runtime": "24.9.0",
+				"jest-snapshot": "24.9.0",
+				"jest-util": "24.9.0",
+				"jest-validate": "24.9.0",
+				"jest-watcher": "24.9.0",
+				"micromatch": "3.1.10",
+				"p-each-series": "1.0.0",
+				"realpath-native": "1.1.0",
+				"rimraf": "2.6.3",
+				"slash": "2.0.0",
+				"strip-ansi": "5.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -770,7 +770,7 @@
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "4.1.0"
 					}
 				}
 			}
@@ -781,10 +781,10 @@
 			"integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"jest-mock": "^24.9.0"
+				"@jest/fake-timers": "24.9.0",
+				"@jest/transform": "24.9.0",
+				"@jest/types": "24.9.0",
+				"jest-mock": "24.9.0"
 			}
 		},
 		"@jest/fake-timers": {
@@ -793,9 +793,9 @@
 			"integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-mock": "^24.9.0"
+				"@jest/types": "24.9.0",
+				"jest-message-util": "24.9.0",
+				"jest-mock": "24.9.0"
 			}
 		},
 		"@jest/reporters": {
@@ -804,27 +804,27 @@
 			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"glob": "^7.1.2",
-				"istanbul-lib-coverage": "^2.0.2",
-				"istanbul-lib-instrument": "^3.0.1",
-				"istanbul-lib-report": "^2.0.4",
-				"istanbul-lib-source-maps": "^3.0.1",
-				"istanbul-reports": "^2.2.6",
-				"jest-haste-map": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.6.0",
-				"node-notifier": "^5.4.2",
-				"slash": "^2.0.0",
-				"source-map": "^0.6.0",
-				"string-length": "^2.0.0"
+				"@jest/environment": "24.9.0",
+				"@jest/test-result": "24.9.0",
+				"@jest/transform": "24.9.0",
+				"@jest/types": "24.9.0",
+				"chalk": "2.3.1",
+				"exit": "0.1.2",
+				"glob": "7.1.4",
+				"istanbul-lib-coverage": "2.0.5",
+				"istanbul-lib-instrument": "3.3.0",
+				"istanbul-lib-report": "2.0.8",
+				"istanbul-lib-source-maps": "3.0.6",
+				"istanbul-reports": "2.2.6",
+				"jest-haste-map": "24.9.0",
+				"jest-resolve": "24.9.0",
+				"jest-runtime": "24.9.0",
+				"jest-util": "24.9.0",
+				"jest-worker": "24.9.0",
+				"node-notifier": "5.4.3",
+				"slash": "2.0.0",
+				"source-map": "0.6.1",
+				"string-length": "2.0.0"
 			},
 			"dependencies": {
 				"slash": {
@@ -847,9 +847,9 @@
 			"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
 			"dev": true,
 			"requires": {
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.1.15",
-				"source-map": "^0.6.0"
+				"callsites": "3.1.0",
+				"graceful-fs": "4.2.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -866,9 +866,9 @@
 			"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/istanbul-lib-coverage": "^2.0.0"
+				"@jest/console": "24.9.0",
+				"@jest/types": "24.9.0",
+				"@types/istanbul-lib-coverage": "2.0.1"
 			}
 		},
 		"@jest/test-sequencer": {
@@ -877,10 +877,10 @@
 			"integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-runner": "^24.9.0",
-				"jest-runtime": "^24.9.0"
+				"@jest/test-result": "24.9.0",
+				"jest-haste-map": "24.9.0",
+				"jest-runner": "24.9.0",
+				"jest-runtime": "24.9.0"
 			}
 		},
 		"@jest/transform": {
@@ -889,21 +889,21 @@
 			"integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.1.0",
-				"@jest/types": "^24.9.0",
-				"babel-plugin-istanbul": "^5.1.0",
-				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.1.15",
-				"jest-haste-map": "^24.9.0",
-				"jest-regex-util": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"micromatch": "^3.1.10",
-				"pirates": "^4.0.1",
-				"realpath-native": "^1.1.0",
-				"slash": "^2.0.0",
-				"source-map": "^0.6.1",
+				"@babel/core": "7.5.5",
+				"@jest/types": "24.9.0",
+				"babel-plugin-istanbul": "5.2.0",
+				"chalk": "2.3.1",
+				"convert-source-map": "1.6.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"graceful-fs": "4.2.0",
+				"jest-haste-map": "24.9.0",
+				"jest-regex-util": "24.9.0",
+				"jest-util": "24.9.0",
+				"micromatch": "3.1.10",
+				"pirates": "4.0.1",
+				"realpath-native": "1.1.0",
+				"slash": "2.0.0",
+				"source-map": "0.6.1",
 				"write-file-atomic": "2.4.1"
 			},
 			"dependencies": {
@@ -927,9 +927,9 @@
 			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
 			"dev": true,
 			"requires": {
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^13.0.0"
+				"@types/istanbul-lib-coverage": "2.0.1",
+				"@types/istanbul-reports": "1.1.1",
+				"@types/yargs": "13.0.2"
 			}
 		},
 		"@marionebl/sander": {
@@ -938,9 +938,9 @@
 			"integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.3",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.2"
+				"graceful-fs": "4.2.0",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.3"
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -950,7 +950,7 @@
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "2.0.1",
-				"run-parallel": "^1.1.9"
+				"run-parallel": "1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
@@ -966,7 +966,7 @@
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.1",
-				"fastq": "^1.6.0"
+				"fastq": "1.6.0"
 			}
 		},
 		"@octokit/endpoint": {
@@ -976,9 +976,9 @@
 			"dev": true,
 			"requires": {
 				"deepmerge": "4.0.0",
-				"is-plain-object": "^3.0.0",
-				"universal-user-agent": "^3.0.0",
-				"url-template": "^2.0.8"
+				"is-plain-object": "3.0.0",
+				"universal-user-agent": "3.0.0",
+				"url-template": "2.0.8"
 			},
 			"dependencies": {
 				"is-plain-object": {
@@ -987,7 +987,7 @@
 					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
 					"dev": true,
 					"requires": {
-						"isobject": "^4.0.0"
+						"isobject": "4.0.0"
 					}
 				},
 				"isobject": {
@@ -1004,13 +1004,13 @@
 			"integrity": "sha512-z1BQr43g4kOL4ZrIVBMHwi68Yg9VbkRUyuAgqCp1rU3vbYa69+2gIld/+gHclw15bJWQnhqqyEb7h5a5EqgZ0A==",
 			"dev": true,
 			"requires": {
-				"@octokit/endpoint": "^5.1.0",
-				"@octokit/request-error": "^1.0.1",
-				"deprecation": "^2.0.0",
-				"is-plain-object": "^3.0.0",
-				"node-fetch": "^2.3.0",
-				"once": "^1.4.0",
-				"universal-user-agent": "^3.0.0"
+				"@octokit/endpoint": "5.3.2",
+				"@octokit/request-error": "1.0.4",
+				"deprecation": "2.3.1",
+				"is-plain-object": "3.0.0",
+				"node-fetch": "2.6.0",
+				"once": "1.4.0",
+				"universal-user-agent": "3.0.0"
 			},
 			"dependencies": {
 				"is-plain-object": {
@@ -1019,7 +1019,7 @@
 					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
 					"dev": true,
 					"requires": {
-						"isobject": "^4.0.0"
+						"isobject": "4.0.0"
 					}
 				},
 				"isobject": {
@@ -1036,8 +1036,8 @@
 			"integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
 			"dev": true,
 			"requires": {
-				"deprecation": "^2.0.0",
-				"once": "^1.4.0"
+				"deprecation": "2.3.1",
+				"once": "1.4.0"
 			}
 		},
 		"@octokit/rest": {
@@ -1046,19 +1046,19 @@
 			"integrity": "sha512-cznFSLEhh22XD3XeqJw51OLSfyL2fcFKUO+v2Ep9MTAFfFLS1cK1Zwd1yEgQJmJoDnj4/vv3+fGGZweG+xsbIA==",
 			"dev": true,
 			"requires": {
-				"@octokit/request": "^5.0.0",
-				"@octokit/request-error": "^1.0.2",
-				"atob-lite": "^2.0.0",
-				"before-after-hook": "^2.0.0",
-				"btoa-lite": "^1.0.0",
-				"deprecation": "^2.0.0",
-				"lodash.get": "^4.4.2",
-				"lodash.set": "^4.3.2",
-				"lodash.uniq": "^4.5.0",
-				"octokit-pagination-methods": "^1.1.0",
-				"once": "^1.4.0",
-				"universal-user-agent": "^3.0.0",
-				"url-template": "^2.0.8"
+				"@octokit/request": "5.0.2",
+				"@octokit/request-error": "1.0.4",
+				"atob-lite": "2.0.0",
+				"before-after-hook": "2.1.0",
+				"btoa-lite": "1.0.0",
+				"deprecation": "2.3.1",
+				"lodash.get": "4.4.2",
+				"lodash.set": "4.3.2",
+				"lodash.uniq": "4.5.0",
+				"octokit-pagination-methods": "1.1.0",
+				"once": "1.4.0",
+				"universal-user-agent": "3.0.0",
+				"url-template": "2.0.8"
 			}
 		},
 		"@peakfijn/config-commitizen": {
@@ -1067,9 +1067,9 @@
 			"integrity": "sha512-v9TYHjLQYznN9NoxJQWn2TnE3u5Nz+/YzQrFN3LtgXusGxyl9tKcYVmtDWx8qpDUjigcQWyMcr6r7xGWka9q1Q==",
 			"dev": true,
 			"requires": {
-				"commitizen": "^3.0.3",
+				"commitizen": "3.1.2",
 				"cz-changelog-peakfijn": "2.1.0",
-				"resolve-pkg": "^2.0.0"
+				"resolve-pkg": "2.0.0"
 			},
 			"dependencies": {
 				"commitizen": {
@@ -1081,13 +1081,13 @@
 						"cachedir": "2.1.0",
 						"cz-conventional-changelog": "2.1.0",
 						"dedent": "0.7.0",
-						"detect-indent": "^5.0.0",
+						"detect-indent": "5.0.0",
 						"find-node-modules": "2.0.0",
 						"find-root": "1.1.0",
-						"fs-extra": "^7.0.0",
+						"fs-extra": "7.0.1",
 						"glob": "7.1.3",
 						"inquirer": "6.2.0",
-						"is-utf8": "^0.2.1",
+						"is-utf8": "0.2.1",
 						"lodash": "4.17.14",
 						"minimist": "1.2.0",
 						"shelljs": "0.7.6",
@@ -1107,9 +1107,9 @@
 					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
+						"graceful-fs": "4.2.0",
+						"jsonfile": "4.0.0",
+						"universalify": "0.1.2"
 					}
 				},
 				"glob": {
@@ -1118,12 +1118,12 @@
 					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.4",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"lodash": {
@@ -1140,9 +1140,9 @@
 			"integrity": "sha512-L+ziFhpA+019tbKYnIEhr3KH+0R/mF6+iAO1H75GBvZxFtMdA0ZTx3lTWR9XgHjwfI+fQCgHMHhlOLgFZizQvA==",
 			"dev": true,
 			"requires": {
-				"commitlint": "^8.1.0",
+				"commitlint": "8.1.0",
 				"commitlint-config-peakfijn": "2.1.0",
-				"resolve-pkg": "^2.0.0"
+				"resolve-pkg": "2.0.0"
 			},
 			"dependencies": {
 				"commitlint": {
@@ -1151,7 +1151,7 @@
 					"integrity": "sha512-eUUnHfx9XKQ7/DesUD4mBO3gSVYRQ4l/NAWR+BMf6XOt/cs2JELkRY9U2ZTbaa41wuCOyKRkKT0s4g16Jnc9Tg==",
 					"dev": true,
 					"requires": {
-						"@commitlint/cli": "^8.1.0",
+						"@commitlint/cli": "8.1.0",
 						"read-pkg": "3.0.0",
 						"resolve-pkg": "2.0.0"
 					},
@@ -1162,10 +1162,10 @@
 							"integrity": "sha512-83K5C2nIAgoZlzMegf0/MEBjX+ampUyc/u79RxgX9ZYjzos+RQtNyO7I43dztVxPXSwAnX9XRgoOfkGWA4nbig==",
 							"dev": true,
 							"requires": {
-								"@commitlint/format": "^8.1.0",
-								"@commitlint/lint": "^8.1.0",
-								"@commitlint/load": "^8.1.0",
-								"@commitlint/read": "^8.1.0",
+								"@commitlint/format": "8.1.0",
+								"@commitlint/lint": "8.1.0",
+								"@commitlint/load": "8.1.0",
+								"@commitlint/read": "8.1.0",
 								"babel-polyfill": "6.26.0",
 								"chalk": "2.3.1",
 								"get-stdin": "7.0.0",
@@ -1191,16 +1191,16 @@
 			"integrity": "sha512-IT2Uk4rWOeA2SrxzBxmKykDJocxCv58VEtJOHlebDWZGAjdAhg2LI/Lr9ubEi9xmUjkTuyuoRg1WC1PqHnkkiQ==",
 			"dev": true,
 			"requires": {
-				"@semantic-release/changelog": "^3.0.4",
-				"@semantic-release/commit-analyzer": "^6.2.0",
-				"@semantic-release/git": "^7.0.16",
-				"@semantic-release/github": "^5.4.2",
-				"@semantic-release/npm": "^5.1.13",
-				"@semantic-release/release-notes-generator": "^7.2.1",
+				"@semantic-release/changelog": "3.0.4",
+				"@semantic-release/commit-analyzer": "6.2.0",
+				"@semantic-release/git": "7.0.16",
+				"@semantic-release/github": "5.4.2",
+				"@semantic-release/npm": "5.1.13",
+				"@semantic-release/release-notes-generator": "7.2.1",
 				"conventional-changelog-peakfijn": "2.1.0",
 				"release-rules-peakfijn": "2.1.0",
-				"resolve-pkg": "^2.0.0",
-				"semantic-release": "^15.13.18"
+				"resolve-pkg": "2.0.0",
+				"semantic-release": "15.13.19"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -1221,9 +1221,9 @@
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"cross-spawn": {
@@ -1232,11 +1232,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.5",
+						"path-key": "2.0.1",
+						"semver": "5.7.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					},
 					"dependencies": {
 						"semver": {
@@ -1253,7 +1253,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"execa": {
@@ -1262,13 +1262,13 @@
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "6.0.5",
+						"get-stream": "4.1.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					},
 					"dependencies": {
 						"get-stream": {
@@ -1277,7 +1277,7 @@
 							"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 							"dev": true,
 							"requires": {
-								"pump": "^3.0.0"
+								"pump": "3.0.0"
 							}
 						}
 					}
@@ -1288,7 +1288,7 @@
 					"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5"
+						"escape-string-regexp": "1.0.5"
 					}
 				},
 				"find-up": {
@@ -1297,8 +1297,8 @@
 					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
+						"locate-path": "5.0.0",
+						"path-exists": "4.0.0"
 					}
 				},
 				"get-stream": {
@@ -1307,7 +1307,7 @@
 					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"pump": "3.0.0"
 					}
 				},
 				"locate-path": {
@@ -1316,7 +1316,7 @@
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^4.1.0"
+						"p-locate": "4.1.0"
 					}
 				},
 				"ms": {
@@ -1331,7 +1331,7 @@
 					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"p-try": "2.2.0"
 					}
 				},
 				"p-locate": {
@@ -1340,7 +1340,7 @@
 					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.2.0"
+						"p-limit": "2.2.0"
 					}
 				},
 				"p-try": {
@@ -1355,10 +1355,10 @@
 					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
-						"lines-and-columns": "^1.1.6"
+						"@babel/code-frame": "7.5.5",
+						"error-ex": "1.3.2",
+						"json-parse-better-errors": "1.0.2",
+						"lines-and-columns": "1.1.6"
 					}
 				},
 				"path-exists": {
@@ -1373,10 +1373,10 @@
 					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 					"dev": true,
 					"requires": {
-						"@types/normalize-package-data": "^2.4.0",
-						"normalize-package-data": "^2.5.0",
-						"parse-json": "^5.0.0",
-						"type-fest": "^0.6.0"
+						"@types/normalize-package-data": "2.4.0",
+						"normalize-package-data": "2.5.0",
+						"parse-json": "5.0.0",
+						"type-fest": "0.6.0"
 					},
 					"dependencies": {
 						"type-fest": {
@@ -1393,9 +1393,9 @@
 					"integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
 					"dev": true,
 					"requires": {
-						"find-up": "^4.0.0",
-						"read-pkg": "^5.1.1",
-						"type-fest": "^0.5.0"
+						"find-up": "4.1.0",
+						"read-pkg": "5.2.0",
+						"type-fest": "0.5.2"
 					}
 				},
 				"semantic-release": {
@@ -1404,32 +1404,32 @@
 					"integrity": "sha512-6eqqAmzGaJWgP5R5IkWIQK9is+cWUp/A+pwzxf/YaG1hJv1eD25klUP7Y0fedsPOxxI8eLuDUVlEs7U8SOlK0Q==",
 					"dev": true,
 					"requires": {
-						"@semantic-release/commit-analyzer": "^6.1.0",
-						"@semantic-release/error": "^2.2.0",
-						"@semantic-release/github": "^5.1.0",
-						"@semantic-release/npm": "^5.0.5",
-						"@semantic-release/release-notes-generator": "^7.1.2",
-						"aggregate-error": "^3.0.0",
-						"cosmiconfig": "^5.0.1",
-						"debug": "^4.0.0",
-						"env-ci": "^4.0.0",
-						"execa": "^1.0.0",
-						"figures": "^3.0.0",
-						"find-versions": "^3.0.0",
-						"get-stream": "^5.0.0",
-						"git-log-parser": "^1.2.0",
-						"hook-std": "^2.0.0",
-						"hosted-git-info": "^2.7.1",
-						"lodash": "^4.17.4",
-						"marked": "^0.7.0",
-						"marked-terminal": "^3.2.0",
-						"p-locate": "^4.0.0",
-						"p-reduce": "^2.0.0",
-						"read-pkg-up": "^6.0.0",
-						"resolve-from": "^5.0.0",
-						"semver": "^6.0.0",
-						"signale": "^1.2.1",
-						"yargs": "^13.1.0"
+						"@semantic-release/commit-analyzer": "6.2.0",
+						"@semantic-release/error": "2.2.0",
+						"@semantic-release/github": "5.4.2",
+						"@semantic-release/npm": "5.1.13",
+						"@semantic-release/release-notes-generator": "7.2.1",
+						"aggregate-error": "3.0.0",
+						"cosmiconfig": "5.2.1",
+						"debug": "4.1.1",
+						"env-ci": "4.1.1",
+						"execa": "1.0.0",
+						"figures": "3.0.0",
+						"find-versions": "3.1.0",
+						"get-stream": "5.1.0",
+						"git-log-parser": "1.2.0",
+						"hook-std": "2.0.0",
+						"hosted-git-info": "2.7.1",
+						"lodash": "4.17.15",
+						"marked": "0.7.0",
+						"marked-terminal": "3.2.0",
+						"p-locate": "4.1.0",
+						"p-reduce": "2.1.0",
+						"read-pkg-up": "6.0.0",
+						"resolve-from": "5.0.0",
+						"semver": "6.3.0",
+						"signale": "1.4.0",
+						"yargs": "13.3.0"
 					},
 					"dependencies": {
 						"env-ci": {
@@ -1438,8 +1438,8 @@
 							"integrity": "sha512-eTgpkALDeYRGNhYM2fO9LKsWDifoUgKL7hxpPZqFMP2IU7f+r89DtKqCmk3yQB/jxS8CmZTfKnWO5TiIDFs9Hw==",
 							"dev": true,
 							"requires": {
-								"execa": "^1.0.0",
-								"java-properties": "^1.0.0"
+								"execa": "1.0.0",
+								"java-properties": "1.0.2"
 							}
 						},
 						"find-up": {
@@ -1448,7 +1448,7 @@
 							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 							"dev": true,
 							"requires": {
-								"locate-path": "^3.0.0"
+								"locate-path": "3.0.0"
 							}
 						},
 						"find-versions": {
@@ -1457,8 +1457,8 @@
 							"integrity": "sha512-NCTfNiVzeE/xL+roNDffGuRbrWI6atI18lTJ22vKp7rs2OhYzMK3W1dIdO2TUndH/QMcacM4d1uWwgcZcHK69Q==",
 							"dev": true,
 							"requires": {
-								"array-uniq": "^2.1.0",
-								"semver-regex": "^2.0.0"
+								"array-uniq": "2.1.0",
+								"semver-regex": "2.0.0"
 							}
 						},
 						"git-log-parser": {
@@ -1467,12 +1467,12 @@
 							"integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
 							"dev": true,
 							"requires": {
-								"argv-formatter": "~1.0.0",
-								"spawn-error-forwarder": "~1.0.0",
-								"split2": "~1.0.0",
-								"stream-combiner2": "~1.1.1",
-								"through2": "~2.0.0",
-								"traverse": "~0.6.6"
+								"argv-formatter": "1.0.0",
+								"spawn-error-forwarder": "1.0.0",
+								"split2": "1.0.0",
+								"stream-combiner2": "1.1.1",
+								"through2": "2.0.5",
+								"traverse": "0.6.6"
 							}
 						},
 						"hook-std": {
@@ -1487,8 +1487,8 @@
 							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 							"dev": true,
 							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
+								"p-locate": "3.0.0",
+								"path-exists": "3.0.0"
 							},
 							"dependencies": {
 								"p-locate": {
@@ -1497,7 +1497,7 @@
 									"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 									"dev": true,
 									"requires": {
-										"p-limit": "^2.0.0"
+										"p-limit": "2.2.0"
 									}
 								}
 							}
@@ -1514,12 +1514,12 @@
 							"integrity": "sha512-Yr1yVS0BbDG55vx7be1D0mdv+jGs9AW563o/Tt/7FTsId2J0yqhrTeXAqq/Q0DyyXltIn6CSxzesQuFqXgafjQ==",
 							"dev": true,
 							"requires": {
-								"ansi-escapes": "^3.1.0",
-								"cardinal": "^2.1.1",
-								"chalk": "^2.4.1",
-								"cli-table": "^0.3.1",
-								"node-emoji": "^1.4.1",
-								"supports-hyperlinks": "^1.0.1"
+								"ansi-escapes": "3.2.0",
+								"cardinal": "2.1.1",
+								"chalk": "2.4.2",
+								"cli-table": "0.3.1",
+								"node-emoji": "1.10.0",
+								"supports-hyperlinks": "1.0.1"
 							}
 						},
 						"path-exists": {
@@ -1540,9 +1540,9 @@
 							"integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
 							"dev": true,
 							"requires": {
-								"chalk": "^2.3.2",
-								"figures": "^2.0.0",
-								"pkg-conf": "^2.1.0"
+								"chalk": "2.4.2",
+								"figures": "2.0.0",
+								"pkg-conf": "2.1.0"
 							},
 							"dependencies": {
 								"figures": {
@@ -1551,7 +1551,7 @@
 									"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 									"dev": true,
 									"requires": {
-										"escape-string-regexp": "^1.0.5"
+										"escape-string-regexp": "1.0.5"
 									}
 								}
 							}
@@ -1562,16 +1562,16 @@
 							"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
 							"dev": true,
 							"requires": {
-								"cliui": "^5.0.0",
-								"find-up": "^3.0.0",
-								"get-caller-file": "^2.0.1",
-								"require-directory": "^2.1.1",
-								"require-main-filename": "^2.0.0",
-								"set-blocking": "^2.0.0",
-								"string-width": "^3.0.0",
-								"which-module": "^2.0.0",
-								"y18n": "^4.0.0",
-								"yargs-parser": "^13.1.1"
+								"cliui": "5.0.0",
+								"find-up": "3.0.0",
+								"get-caller-file": "2.0.5",
+								"require-directory": "2.1.1",
+								"require-main-filename": "2.0.0",
+								"set-blocking": "2.0.0",
+								"string-width": "3.1.0",
+								"which-module": "2.0.0",
+								"y18n": "4.0.0",
+								"yargs-parser": "13.1.1"
 							}
 						}
 					}
@@ -1582,7 +1582,7 @@
 					"integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
 					"dev": true,
 					"requires": {
-						"through2": "~2.0.0"
+						"through2": "2.0.5"
 					}
 				},
 				"string-width": {
@@ -1591,9 +1591,9 @@
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"emoji-regex": "7.0.3",
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "5.2.0"
 					}
 				},
 				"strip-ansi": {
@@ -1602,7 +1602,7 @@
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "4.1.0"
 					}
 				},
 				"type-fest": {
@@ -1617,8 +1617,8 @@
 					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
+						"camelcase": "5.3.1",
+						"decamelize": "1.2.0"
 					}
 				}
 			}
@@ -1629,10 +1629,10 @@
 			"integrity": "sha512-UqEPahcZSW0IKtzOglyjeEZCN99ku6Wb/yH/iOKEBJ7Vkw0/+Fc3VRiGoXTkMfHSFUJk+4UkoQKTlYuwf61C2w==",
 			"dev": true,
 			"requires": {
-				"@semantic-release/error": "^2.1.0",
-				"aggregate-error": "^3.0.0",
-				"fs-extra": "^8.0.0",
-				"lodash": "^4.17.4"
+				"@semantic-release/error": "2.2.0",
+				"aggregate-error": "3.0.0",
+				"fs-extra": "8.1.0",
+				"lodash": "4.17.15"
 			}
 		},
 		"@semantic-release/commit-analyzer": {
@@ -1641,12 +1641,12 @@
 			"integrity": "sha512-oUtPydYcbtJsEY6WCPi4wynTgRecK5zCkKaGmHi+9Xl7d6jGf7LomnJCg++6dNF1tyavrbGMSdXTCPH6Dx9LbA==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-angular": "^5.0.0",
-				"conventional-commits-filter": "^2.0.0",
-				"conventional-commits-parser": "^3.0.0",
-				"debug": "^4.0.0",
-				"import-from": "^3.0.0",
-				"lodash": "^4.17.4"
+				"conventional-changelog-angular": "5.0.3",
+				"conventional-commits-filter": "2.0.1",
+				"conventional-commits-parser": "3.0.1",
+				"debug": "4.1.1",
+				"import-from": "3.0.0",
+				"lodash": "4.17.15"
 			},
 			"dependencies": {
 				"conventional-changelog-angular": {
@@ -1655,8 +1655,8 @@
 					"integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
 					"dev": true,
 					"requires": {
-						"compare-func": "^1.3.1",
-						"q": "^1.5.1"
+						"compare-func": "1.3.2",
+						"q": "1.5.1"
 					}
 				},
 				"conventional-commits-parser": {
@@ -1665,13 +1665,13 @@
 					"integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
 					"dev": true,
 					"requires": {
-						"JSONStream": "^1.0.4",
-						"is-text-path": "^1.0.0",
-						"lodash": "^4.2.1",
-						"meow": "^4.0.0",
-						"split2": "^2.0.0",
-						"through2": "^2.0.0",
-						"trim-off-newlines": "^1.0.0"
+						"JSONStream": "1.3.5",
+						"is-text-path": "1.0.1",
+						"lodash": "4.17.15",
+						"meow": "4.0.1",
+						"split2": "2.2.0",
+						"through2": "2.0.5",
+						"trim-off-newlines": "1.0.1"
 					}
 				},
 				"debug": {
@@ -1680,7 +1680,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"meow": {
@@ -1689,15 +1689,15 @@
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist": "^1.1.3",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0"
+						"camelcase-keys": "4.2.0",
+						"decamelize-keys": "1.1.0",
+						"loud-rejection": "1.6.0",
+						"minimist": "1.2.0",
+						"minimist-options": "3.0.2",
+						"normalize-package-data": "2.5.0",
+						"read-pkg-up": "3.0.0",
+						"redent": "2.0.0",
+						"trim-newlines": "2.0.0"
 					}
 				},
 				"ms": {
@@ -1720,16 +1720,16 @@
 			"integrity": "sha512-Bw/npxTVTeFPnQZmuczWRGRdxqJpWOOFZENx38ykyp42InwDFm4n72bfcCwmP/J4WqkPmMR4p+IracWruz/RUw==",
 			"dev": true,
 			"requires": {
-				"@semantic-release/error": "^2.1.0",
-				"aggregate-error": "^3.0.0",
-				"debug": "^4.0.0",
-				"dir-glob": "^3.0.0",
-				"execa": "^1.0.0",
-				"fs-extra": "^8.0.0",
-				"globby": "^10.0.0",
-				"lodash": "^4.17.4",
-				"micromatch": "^4.0.0",
-				"p-reduce": "^2.0.0"
+				"@semantic-release/error": "2.2.0",
+				"aggregate-error": "3.0.0",
+				"debug": "4.1.1",
+				"dir-glob": "3.0.1",
+				"execa": "1.0.0",
+				"fs-extra": "8.1.0",
+				"globby": "10.0.1",
+				"lodash": "4.17.15",
+				"micromatch": "4.0.2",
+				"p-reduce": "2.1.0"
 			},
 			"dependencies": {
 				"braces": {
@@ -1738,7 +1738,7 @@
 					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 					"dev": true,
 					"requires": {
-						"fill-range": "^7.0.1"
+						"fill-range": "7.0.1"
 					}
 				},
 				"cross-spawn": {
@@ -1747,11 +1747,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.5",
+						"path-key": "2.0.1",
+						"semver": "5.7.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					}
 				},
 				"debug": {
@@ -1760,7 +1760,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"execa": {
@@ -1769,13 +1769,13 @@
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "6.0.5",
+						"get-stream": "4.1.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"fill-range": {
@@ -1784,7 +1784,7 @@
 					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
 					"dev": true,
 					"requires": {
-						"to-regex-range": "^5.0.1"
+						"to-regex-range": "5.0.1"
 					}
 				},
 				"get-stream": {
@@ -1793,7 +1793,7 @@
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"pump": "3.0.0"
 					}
 				},
 				"is-number": {
@@ -1808,8 +1808,8 @@
 					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
 					"dev": true,
 					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
+						"braces": "3.0.2",
+						"picomatch": "2.0.7"
 					}
 				},
 				"ms": {
@@ -1830,7 +1830,7 @@
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"dev": true,
 					"requires": {
-						"is-number": "^7.0.0"
+						"is-number": "7.0.0"
 					}
 				}
 			}
@@ -1841,23 +1841,23 @@
 			"integrity": "sha512-8gkOa5tED/+sjAPwZRYsLaGr6VuAGLZinSvLsuF9/l4qLeYV8gvj7fhjFJepGu6y31t7PR2J9SWzmsqsBAyyKQ==",
 			"dev": true,
 			"requires": {
-				"@octokit/rest": "^16.27.0",
-				"@semantic-release/error": "^2.2.0",
-				"aggregate-error": "^3.0.0",
-				"bottleneck": "^2.18.1",
-				"debug": "^4.0.0",
-				"dir-glob": "^3.0.0",
-				"fs-extra": "^8.0.0",
-				"globby": "^10.0.0",
-				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^2.2.1",
-				"issue-parser": "^4.0.0",
-				"lodash": "^4.17.4",
-				"mime": "^2.4.3",
-				"p-filter": "^2.0.0",
-				"p-retry": "^4.0.0",
-				"parse-github-url": "^1.0.1",
-				"url-join": "^4.0.0"
+				"@octokit/rest": "16.28.7",
+				"@semantic-release/error": "2.2.0",
+				"aggregate-error": "3.0.0",
+				"bottleneck": "2.19.4",
+				"debug": "4.1.1",
+				"dir-glob": "3.0.1",
+				"fs-extra": "8.1.0",
+				"globby": "10.0.1",
+				"http-proxy-agent": "2.1.0",
+				"https-proxy-agent": "2.2.4",
+				"issue-parser": "4.0.0",
+				"lodash": "4.17.15",
+				"mime": "2.4.4",
+				"p-filter": "2.1.0",
+				"p-retry": "4.1.0",
+				"parse-github-url": "1.0.2",
+				"url-join": "4.0.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -1866,7 +1866,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -1883,17 +1883,17 @@
 			"integrity": "sha512-pONvpoEtGH1nd6Wj3SryACNJ/YXXsvSSekE9Pdk6mnaRv7lGhXdaeJJr6Lr4L8WK98oZv4aJOr68vTac2Oc+dA==",
 			"dev": true,
 			"requires": {
-				"@semantic-release/error": "^2.2.0",
-				"aggregate-error": "^3.0.0",
-				"execa": "^1.0.0",
-				"fs-extra": "^8.0.0",
-				"lodash": "^4.17.4",
-				"nerf-dart": "^1.0.0",
-				"normalize-url": "^4.0.0",
-				"npm": "^6.8.0",
-				"rc": "^1.2.8",
-				"read-pkg": "^5.0.0",
-				"registry-auth-token": "^4.0.0"
+				"@semantic-release/error": "2.2.0",
+				"aggregate-error": "3.0.0",
+				"execa": "1.0.0",
+				"fs-extra": "8.1.0",
+				"lodash": "4.17.15",
+				"nerf-dart": "1.0.0",
+				"normalize-url": "4.3.0",
+				"npm": "6.13.4",
+				"rc": "1.2.8",
+				"read-pkg": "5.2.0",
+				"registry-auth-token": "4.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -1902,11 +1902,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.5",
+						"path-key": "2.0.1",
+						"semver": "5.7.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					}
 				},
 				"execa": {
@@ -1915,13 +1915,13 @@
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "6.0.5",
+						"get-stream": "4.1.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"get-stream": {
@@ -1930,7 +1930,7 @@
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"pump": "3.0.0"
 					}
 				},
 				"parse-json": {
@@ -1939,10 +1939,10 @@
 					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
-						"lines-and-columns": "^1.1.6"
+						"@babel/code-frame": "7.5.5",
+						"error-ex": "1.3.2",
+						"json-parse-better-errors": "1.0.2",
+						"lines-and-columns": "1.1.6"
 					}
 				},
 				"read-pkg": {
@@ -1951,10 +1951,10 @@
 					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 					"dev": true,
 					"requires": {
-						"@types/normalize-package-data": "^2.4.0",
-						"normalize-package-data": "^2.5.0",
-						"parse-json": "^5.0.0",
-						"type-fest": "^0.6.0"
+						"@types/normalize-package-data": "2.4.0",
+						"normalize-package-data": "2.5.0",
+						"parse-json": "5.0.0",
+						"type-fest": "0.6.0"
 					}
 				},
 				"semver": {
@@ -1971,16 +1971,16 @@
 			"integrity": "sha512-TdlYgYH6amhE80i9L9HPcTwYzk4Rma7qM1g7XJEEfip7dNXWgmrBeibN4DJmTg/qrUFDd4GD86lFDcYXNZDNow==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-angular": "^5.0.0",
-				"conventional-changelog-writer": "^4.0.0",
-				"conventional-commits-filter": "^2.0.0",
-				"conventional-commits-parser": "^3.0.0",
-				"debug": "^4.0.0",
-				"get-stream": "^5.0.0",
-				"import-from": "^3.0.0",
-				"into-stream": "^5.0.0",
-				"lodash": "^4.17.4",
-				"read-pkg-up": "^6.0.0"
+				"conventional-changelog-angular": "5.0.3",
+				"conventional-changelog-writer": "4.0.3",
+				"conventional-commits-filter": "2.0.1",
+				"conventional-commits-parser": "3.0.1",
+				"debug": "4.1.1",
+				"get-stream": "5.1.0",
+				"import-from": "3.0.0",
+				"into-stream": "5.1.0",
+				"lodash": "4.17.15",
+				"read-pkg-up": "6.0.0"
 			},
 			"dependencies": {
 				"conventional-changelog-angular": {
@@ -1989,8 +1989,8 @@
 					"integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
 					"dev": true,
 					"requires": {
-						"compare-func": "^1.3.1",
-						"q": "^1.5.1"
+						"compare-func": "1.3.2",
+						"q": "1.5.1"
 					}
 				},
 				"conventional-commits-parser": {
@@ -1999,13 +1999,13 @@
 					"integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
 					"dev": true,
 					"requires": {
-						"JSONStream": "^1.0.4",
-						"is-text-path": "^1.0.0",
-						"lodash": "^4.2.1",
-						"meow": "^4.0.0",
-						"split2": "^2.0.0",
-						"through2": "^2.0.0",
-						"trim-off-newlines": "^1.0.0"
+						"JSONStream": "1.3.5",
+						"is-text-path": "1.0.1",
+						"lodash": "4.17.15",
+						"meow": "4.0.1",
+						"split2": "2.2.0",
+						"through2": "2.0.5",
+						"trim-off-newlines": "1.0.1"
 					}
 				},
 				"debug": {
@@ -2014,7 +2014,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"get-stream": {
@@ -2023,7 +2023,7 @@
 					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"pump": "3.0.0"
 					}
 				},
 				"locate-path": {
@@ -2032,7 +2032,7 @@
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^4.1.0"
+						"p-locate": "4.1.0"
 					}
 				},
 				"meow": {
@@ -2041,15 +2041,15 @@
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist": "^1.1.3",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0"
+						"camelcase-keys": "4.2.0",
+						"decamelize-keys": "1.1.0",
+						"loud-rejection": "1.6.0",
+						"minimist": "1.2.0",
+						"minimist-options": "3.0.2",
+						"normalize-package-data": "2.5.0",
+						"read-pkg-up": "3.0.0",
+						"redent": "2.0.0",
+						"trim-newlines": "2.0.0"
 					},
 					"dependencies": {
 						"read-pkg-up": {
@@ -2058,8 +2058,8 @@
 							"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 							"dev": true,
 							"requires": {
-								"find-up": "^2.0.0",
-								"read-pkg": "^3.0.0"
+								"find-up": "2.1.0",
+								"read-pkg": "3.0.0"
 							}
 						}
 					}
@@ -2076,7 +2076,7 @@
 					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"p-try": "2.2.0"
 					}
 				},
 				"p-locate": {
@@ -2085,7 +2085,7 @@
 					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.2.0"
+						"p-limit": "2.2.0"
 					}
 				},
 				"p-try": {
@@ -2100,10 +2100,10 @@
 					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
-						"lines-and-columns": "^1.1.6"
+						"@babel/code-frame": "7.5.5",
+						"error-ex": "1.3.2",
+						"json-parse-better-errors": "1.0.2",
+						"lines-and-columns": "1.1.6"
 					}
 				},
 				"path-exists": {
@@ -2118,9 +2118,9 @@
 					"integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
 					"dev": true,
 					"requires": {
-						"find-up": "^4.0.0",
-						"read-pkg": "^5.1.1",
-						"type-fest": "^0.5.0"
+						"find-up": "4.1.0",
+						"read-pkg": "5.2.0",
+						"type-fest": "0.5.2"
 					},
 					"dependencies": {
 						"find-up": {
@@ -2129,8 +2129,8 @@
 							"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 							"dev": true,
 							"requires": {
-								"locate-path": "^5.0.0",
-								"path-exists": "^4.0.0"
+								"locate-path": "5.0.0",
+								"path-exists": "4.0.0"
 							}
 						},
 						"read-pkg": {
@@ -2139,10 +2139,10 @@
 							"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 							"dev": true,
 							"requires": {
-								"@types/normalize-package-data": "^2.4.0",
-								"normalize-package-data": "^2.5.0",
-								"parse-json": "^5.0.0",
-								"type-fest": "^0.6.0"
+								"@types/normalize-package-data": "2.4.0",
+								"normalize-package-data": "2.5.0",
+								"parse-json": "5.0.0",
+								"type-fest": "0.6.0"
 							},
 							"dependencies": {
 								"type-fest": {
@@ -2169,11 +2169,11 @@
 			"integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
 			"dev": true,
 			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
+				"@babel/parser": "7.5.5",
+				"@babel/types": "7.5.5",
+				"@types/babel__generator": "7.0.2",
+				"@types/babel__template": "7.0.2",
+				"@types/babel__traverse": "7.0.7"
 			}
 		},
 		"@types/babel__generator": {
@@ -2182,7 +2182,7 @@
 			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "7.5.5"
 			}
 		},
 		"@types/babel__template": {
@@ -2191,8 +2191,8 @@
 			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
 			"dev": true,
 			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/parser": "7.5.5",
+				"@babel/types": "7.5.5"
 			}
 		},
 		"@types/babel__traverse": {
@@ -2201,7 +2201,7 @@
 			"integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.3.0"
+				"@babel/types": "7.5.5"
 			}
 		},
 		"@types/detect-indent": {
@@ -2210,7 +2210,7 @@
 			"integrity": "sha512-KeE9HzRWAoOy/YPEMzNbljqTmDR7JXCD8NpOwSjta9oWoL8+i9E2KzwUX0nb1b78iB481RSJ5XIxHfjaJnUtvA==",
 			"dev": true,
 			"requires": {
-				"detect-indent": "*"
+				"detect-indent": "6.0.0"
 			}
 		},
 		"@types/eslint-visitor-keys": {
@@ -2231,7 +2231,7 @@
 			"integrity": "sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*"
+				"@types/node": "13.1.2"
 			}
 		},
 		"@types/glob": {
@@ -2240,9 +2240,9 @@
 			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
 			"dev": true,
 			"requires": {
-				"@types/events": "*",
-				"@types/minimatch": "*",
-				"@types/node": "*"
+				"@types/events": "3.0.0",
+				"@types/minimatch": "3.0.3",
+				"@types/node": "13.1.2"
 			}
 		},
 		"@types/istanbul-lib-coverage": {
@@ -2257,7 +2257,7 @@
 			"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
 			"dev": true,
 			"requires": {
-				"@types/istanbul-lib-coverage": "*"
+				"@types/istanbul-lib-coverage": "2.0.1"
 			}
 		},
 		"@types/istanbul-reports": {
@@ -2266,8 +2266,8 @@
 			"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
 			"dev": true,
 			"requires": {
-				"@types/istanbul-lib-coverage": "*",
-				"@types/istanbul-lib-report": "*"
+				"@types/istanbul-lib-coverage": "2.0.1",
+				"@types/istanbul-lib-report": "1.1.1"
 			}
 		},
 		"@types/jest": {
@@ -2276,7 +2276,7 @@
 			"integrity": "sha512-hnP1WpjN4KbGEK4dLayul6lgtys6FPz0UfxMeMQCv0M+sTnzN3ConfiO72jHgLxl119guHgI8gLqDOrRLsyp2g==",
 			"dev": true,
 			"requires": {
-				"jest-diff": "^24.3.0"
+				"jest-diff": "24.9.0"
 			}
 		},
 		"@types/json-schema": {
@@ -2333,7 +2333,7 @@
 			"integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
 			"dev": true,
 			"requires": {
-				"@types/yargs-parser": "*"
+				"@types/yargs-parser": "13.0.0"
 			}
 		},
 		"@types/yargs-parser": {
@@ -2349,10 +2349,10 @@
 			"dev": true,
 			"requires": {
 				"@typescript-eslint/experimental-utils": "1.13.0",
-				"eslint-utils": "^1.3.1",
-				"functional-red-black-tree": "^1.0.1",
-				"regexpp": "^2.0.1",
-				"tsutils": "^3.7.0"
+				"eslint-utils": "1.4.2",
+				"functional-red-black-tree": "1.0.1",
+				"regexpp": "2.0.1",
+				"tsutils": "3.14.1"
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
@@ -2361,9 +2361,9 @@
 			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
 			"dev": true,
 			"requires": {
-				"@types/json-schema": "^7.0.3",
+				"@types/json-schema": "7.0.3",
 				"@typescript-eslint/typescript-estree": "1.13.0",
-				"eslint-scope": "^4.0.0"
+				"eslint-scope": "4.0.3"
 			}
 		},
 		"@typescript-eslint/parser": {
@@ -2372,10 +2372,10 @@
 			"integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
 			"dev": true,
 			"requires": {
-				"@types/eslint-visitor-keys": "^1.0.0",
+				"@types/eslint-visitor-keys": "1.0.0",
 				"@typescript-eslint/experimental-utils": "1.13.0",
 				"@typescript-eslint/typescript-estree": "1.13.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "1.0.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
@@ -2402,8 +2402,8 @@
 			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
 			"dev": true,
 			"requires": {
-				"jsonparse": "^1.2.0",
-				"through": ">=2.2.7 <3"
+				"jsonparse": "1.3.1",
+				"through": "2.3.8"
 			}
 		},
 		"abab": {
@@ -2424,8 +2424,8 @@
 			"integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
+				"acorn": "6.2.1",
+				"acorn-walk": "6.2.0"
 			}
 		},
 		"acorn-jsx": {
@@ -2446,7 +2446,7 @@
 			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
 			"dev": true,
 			"requires": {
-				"es6-promisify": "^5.0.0"
+				"es6-promisify": "5.0.0"
 			}
 		},
 		"aggregate-error": {
@@ -2455,8 +2455,8 @@
 			"integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
 			"dev": true,
 			"requires": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^3.2.0"
+				"clean-stack": "2.1.0",
+				"indent-string": "3.2.0"
 			}
 		},
 		"ajv": {
@@ -2465,10 +2465,10 @@
 			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"dev": true,
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "2.0.1",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.4.1",
+				"uri-js": "4.2.2"
 			}
 		},
 		"ansi-escapes": {
@@ -2489,7 +2489,7 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "1.9.3"
 			}
 		},
 		"ansicolors": {
@@ -2504,8 +2504,8 @@
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"micromatch": "3.1.10",
+				"normalize-path": "2.1.1"
 			}
 		},
 		"argparse": {
@@ -2514,7 +2514,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"argv": {
@@ -2595,7 +2595,7 @@
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "~2.1.0"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"assert-plus": {
@@ -2658,13 +2658,13 @@
 			"integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/babel__core": "^7.1.0",
-				"babel-plugin-istanbul": "^5.1.0",
-				"babel-preset-jest": "^24.9.0",
-				"chalk": "^2.4.2",
-				"slash": "^2.0.0"
+				"@jest/transform": "24.9.0",
+				"@jest/types": "24.9.0",
+				"@types/babel__core": "7.1.2",
+				"babel-plugin-istanbul": "5.2.0",
+				"babel-preset-jest": "24.9.0",
+				"chalk": "2.4.2",
+				"slash": "2.0.0"
 			},
 			"dependencies": {
 				"chalk": {
@@ -2673,9 +2673,9 @@
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"slash": {
@@ -2692,10 +2692,10 @@
 			"integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"find-up": "^3.0.0",
-				"istanbul-lib-instrument": "^3.3.0",
-				"test-exclude": "^5.2.3"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"find-up": "3.0.0",
+				"istanbul-lib-instrument": "3.3.0",
+				"test-exclude": "5.2.3"
 			},
 			"dependencies": {
 				"find-up": {
@@ -2704,7 +2704,7 @@
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"locate-path": "3.0.0"
 					}
 				},
 				"locate-path": {
@@ -2713,8 +2713,8 @@
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "3.0.0",
+						"path-exists": "3.0.0"
 					}
 				},
 				"p-limit": {
@@ -2723,7 +2723,7 @@
 					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"p-try": "2.2.0"
 					}
 				},
 				"p-locate": {
@@ -2732,7 +2732,7 @@
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "2.2.1"
 					}
 				},
 				"p-try": {
@@ -2749,7 +2749,7 @@
 			"integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
 			"dev": true,
 			"requires": {
-				"@types/babel__traverse": "^7.0.6"
+				"@types/babel__traverse": "7.0.7"
 			}
 		},
 		"babel-polyfill": {
@@ -2758,9 +2758,9 @@
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"regenerator-runtime": "^0.10.5"
+				"babel-runtime": "6.26.0",
+				"core-js": "2.6.9",
+				"regenerator-runtime": "0.10.5"
 			},
 			"dependencies": {
 				"regenerator-runtime": {
@@ -2777,8 +2777,8 @@
 			"integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
 			"dev": true,
 			"requires": {
-				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"babel-plugin-jest-hoist": "^24.9.0"
+				"@babel/plugin-syntax-object-rest-spread": "7.2.0",
+				"babel-plugin-jest-hoist": "24.9.0"
 			}
 		},
 		"babel-runtime": {
@@ -2787,8 +2787,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.6.9",
+				"regenerator-runtime": "0.11.1"
 			}
 		},
 		"balanced-match": {
@@ -2803,13 +2803,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.3.0",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.2",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2818,7 +2818,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -2827,7 +2827,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -2836,7 +2836,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2845,9 +2845,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -2858,7 +2858,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"before-after-hook": {
@@ -2879,7 +2879,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -2889,16 +2889,16 @@
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
+				"arr-flatten": "1.1.0",
+				"array-unique": "0.3.2",
+				"extend-shallow": "2.0.1",
+				"fill-range": "4.0.0",
+				"isobject": "3.0.1",
+				"repeat-element": "1.1.3",
+				"snapdragon": "0.8.2",
+				"snapdragon-node": "2.1.1",
+				"split-string": "3.1.0",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -2907,7 +2907,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -2941,7 +2941,7 @@
 			"integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
 			"dev": true,
 			"requires": {
-				"fast-json-stable-stringify": "2.x"
+				"fast-json-stable-stringify": "2.0.0"
 			}
 		},
 		"bser": {
@@ -2950,7 +2950,7 @@
 			"integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
 			"dev": true,
 			"requires": {
-				"node-int64": "^0.4.0"
+				"node-int64": "0.4.0"
 			}
 		},
 		"btoa-lite": {
@@ -2971,15 +2971,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.3.0",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.1",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.1",
+				"unset-value": "1.0.0"
 			}
 		},
 		"cachedir": {
@@ -2994,7 +2994,7 @@
 			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
 			"dev": true,
 			"requires": {
-				"callsites": "^2.0.0"
+				"callsites": "2.0.0"
 			},
 			"dependencies": {
 				"callsites": {
@@ -3011,7 +3011,7 @@
 			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
 			"dev": true,
 			"requires": {
-				"caller-callsite": "^2.0.0"
+				"caller-callsite": "2.0.0"
 			}
 		},
 		"callsites": {
@@ -3032,9 +3032,9 @@
 			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0",
-				"map-obj": "^2.0.0",
-				"quick-lru": "^1.0.0"
+				"camelcase": "4.1.0",
+				"map-obj": "2.0.0",
+				"quick-lru": "1.1.0"
 			}
 		},
 		"capture-exit": {
@@ -3043,7 +3043,7 @@
 			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
 			"dev": true,
 			"requires": {
-				"rsvp": "^4.8.4"
+				"rsvp": "4.8.5"
 			}
 		},
 		"cardinal": {
@@ -3052,8 +3052,8 @@
 			"integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
 			"dev": true,
 			"requires": {
-				"ansicolors": "~0.3.2",
-				"redeyed": "~2.1.0"
+				"ansicolors": "0.3.2",
+				"redeyed": "2.1.1"
 			}
 		},
 		"caseless": {
@@ -3068,9 +3068,9 @@
 			"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.2.0"
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.5.0"
 			}
 		},
 		"chardet": {
@@ -3091,10 +3091,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -3103,7 +3103,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -3120,7 +3120,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-table": {
@@ -3144,9 +3144,9 @@
 			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 			"dev": true,
 			"requires": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
+				"string-width": "3.1.0",
+				"strip-ansi": "5.2.0",
+				"wrap-ansi": "5.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3161,9 +3161,9 @@
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"emoji-regex": "7.0.3",
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "5.2.0"
 					}
 				},
 				"strip-ansi": {
@@ -3172,7 +3172,7 @@
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "4.1.0"
 					}
 				}
 			}
@@ -3189,11 +3189,11 @@
 			"integrity": "sha512-IUJB6WG47nWK7o50etF8jBadxdMw7DmoQg05yIljstXFBGB6clOZsIj6iD4P82T2YaIU3qq+FFu8K9pxgkCJDQ==",
 			"dev": true,
 			"requires": {
-				"argv": "^0.0.2",
-				"ignore-walk": "^3.0.1",
-				"js-yaml": "^3.13.1",
-				"teeny-request": "^3.11.3",
-				"urlgrey": "^0.4.4"
+				"argv": "0.0.2",
+				"ignore-walk": "3.0.2",
+				"js-yaml": "3.13.1",
+				"teeny-request": "3.11.3",
+				"urlgrey": "0.4.4"
 			}
 		},
 		"collection-visit": {
@@ -3202,8 +3202,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color-convert": {
@@ -3233,7 +3233,7 @@
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
@@ -3255,7 +3255,7 @@
 			"integrity": "sha512-I+YpXnI5NZ8aLKa/R+Y2ZFzo2efSo+DjjUHrLKSNAiU9CXHNp6hMufB0kN5pKD16mde6jj+IMUgECuwpjcgt3A==",
 			"dev": true,
 			"requires": {
-				"@commitlint/config-conventional": "^8.1.0",
+				"@commitlint/config-conventional": "8.1.0",
 				"commit-types-peakfijn": "2.1.0"
 			}
 		},
@@ -3265,8 +3265,8 @@
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
 			"dev": true,
 			"requires": {
-				"array-ify": "^1.0.0",
-				"dot-prop": "^3.0.0"
+				"array-ify": "1.0.0",
+				"dot-prop": "3.0.0"
 			}
 		},
 		"component-emitter": {
@@ -3287,8 +3287,8 @@
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
 			"dev": true,
 			"requires": {
-				"compare-func": "^1.3.1",
-				"q": "^1.5.1"
+				"compare-func": "1.3.2",
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-peakfijn": {
@@ -3298,8 +3298,8 @@
 			"dev": true,
 			"requires": {
 				"commit-types-peakfijn": "2.1.0",
-				"conventional-changelog-angular": "^5.0.0",
-				"q": "^1.5.1"
+				"conventional-changelog-angular": "5.0.3",
+				"q": "1.5.1"
 			},
 			"dependencies": {
 				"conventional-changelog-angular": {
@@ -3308,8 +3308,8 @@
 					"integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
 					"dev": true,
 					"requires": {
-						"compare-func": "^1.3.1",
-						"q": "^1.5.1"
+						"compare-func": "1.3.2",
+						"q": "1.5.1"
 					}
 				}
 			}
@@ -3320,16 +3320,16 @@
 			"integrity": "sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==",
 			"dev": true,
 			"requires": {
-				"compare-func": "^1.3.1",
-				"conventional-commits-filter": "^2.0.1",
-				"dateformat": "^3.0.0",
-				"handlebars": "^4.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.2.1",
-				"meow": "^4.0.0",
-				"semver": "^5.5.0",
-				"split": "^1.0.0",
-				"through2": "^2.0.0"
+				"compare-func": "1.3.2",
+				"conventional-commits-filter": "2.0.1",
+				"dateformat": "3.0.3",
+				"handlebars": "4.5.3",
+				"json-stringify-safe": "5.0.1",
+				"lodash": "4.17.15",
+				"meow": "4.0.1",
+				"semver": "5.7.0",
+				"split": "1.0.1",
+				"through2": "2.0.5"
 			},
 			"dependencies": {
 				"meow": {
@@ -3338,15 +3338,15 @@
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist": "^1.1.3",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0"
+						"camelcase-keys": "4.2.0",
+						"decamelize-keys": "1.1.0",
+						"loud-rejection": "1.6.0",
+						"minimist": "1.2.0",
+						"minimist-options": "3.0.2",
+						"normalize-package-data": "2.5.0",
+						"read-pkg-up": "3.0.0",
+						"redent": "2.0.0",
+						"trim-newlines": "2.0.0"
 					}
 				},
 				"semver": {
@@ -3369,8 +3369,8 @@
 			"integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
 			"dev": true,
 			"requires": {
-				"is-subset": "^0.1.1",
-				"modify-values": "^1.0.0"
+				"is-subset": "0.1.1",
+				"modify-values": "1.0.1"
 			}
 		},
 		"conventional-commits-parser": {
@@ -3379,13 +3379,13 @@
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "^1.0.4",
-				"is-text-path": "^1.0.0",
-				"lodash": "^4.2.1",
-				"meow": "^4.0.0",
-				"split2": "^2.0.0",
-				"through2": "^2.0.0",
-				"trim-off-newlines": "^1.0.0"
+				"JSONStream": "1.3.5",
+				"is-text-path": "1.0.1",
+				"lodash": "4.17.15",
+				"meow": "4.0.1",
+				"split2": "2.2.0",
+				"through2": "2.0.5",
+				"trim-off-newlines": "1.0.1"
 			},
 			"dependencies": {
 				"meow": {
@@ -3394,15 +3394,15 @@
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist": "^1.1.3",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0"
+						"camelcase-keys": "4.2.0",
+						"decamelize-keys": "1.1.0",
+						"loud-rejection": "1.6.0",
+						"minimist": "1.2.0",
+						"minimist-options": "3.0.2",
+						"normalize-package-data": "2.5.0",
+						"read-pkg-up": "3.0.0",
+						"redent": "2.0.0",
+						"trim-newlines": "2.0.0"
 					}
 				}
 			}
@@ -3413,7 +3413,7 @@
 			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"copy-descriptor": {
@@ -3440,10 +3440,10 @@
 			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
 			"dev": true,
 			"requires": {
-				"import-fresh": "^2.0.0",
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.13.1",
-				"parse-json": "^4.0.0"
+				"import-fresh": "2.0.0",
+				"is-directory": "0.3.1",
+				"js-yaml": "3.13.1",
+				"parse-json": "4.0.0"
 			},
 			"dependencies": {
 				"import-fresh": {
@@ -3452,8 +3452,8 @@
 					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
 					"dev": true,
 					"requires": {
-						"caller-path": "^2.0.0",
-						"resolve-from": "^3.0.0"
+						"caller-path": "2.0.0",
+						"resolve-from": "3.0.0"
 					}
 				},
 				"resolve-from": {
@@ -3470,11 +3470,11 @@
 			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"nice-try": "1.0.5",
+				"path-key": "2.0.1",
+				"semver": "5.7.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.1"
 			},
 			"dependencies": {
 				"semver": {
@@ -3497,7 +3497,7 @@
 			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "0.3.8"
 			}
 		},
 		"currently-unhandled": {
@@ -3506,7 +3506,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "^1.0.1"
+				"array-find-index": "1.0.2"
 			}
 		},
 		"cz-changelog-peakfijn": {
@@ -3515,9 +3515,9 @@
 			"integrity": "sha512-27/qrFPoHKd7DzJvLkwKUAIJCa6HD9SuhfYg8yo1NYlU3xusamBhmH3MnH8R7CoOhEaSXmd++PrExQCBZHT60w==",
 			"dev": true,
 			"requires": {
-				"@commitlint/lint": "^8.1.0",
-				"@commitlint/load": "^8.1.0",
-				"chalk": "^2.4.1",
+				"@commitlint/lint": "8.1.0",
+				"@commitlint/load": "8.1.0",
+				"chalk": "2.4.2",
 				"commit-types-peakfijn": "2.1.0",
 				"commitlint-config-peakfijn": "2.1.0"
 			},
@@ -3528,9 +3528,9 @@
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				}
 			}
@@ -3541,11 +3541,11 @@
 			"integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
 			"dev": true,
 			"requires": {
-				"conventional-commit-types": "^2.0.0",
-				"lodash.map": "^4.5.1",
-				"longest": "^1.0.1",
-				"right-pad": "^1.0.1",
-				"word-wrap": "^1.0.3"
+				"conventional-commit-types": "2.1.1",
+				"lodash.map": "4.6.0",
+				"longest": "1.0.1",
+				"right-pad": "1.0.1",
+				"word-wrap": "1.2.3"
 			}
 		},
 		"dargs": {
@@ -3554,7 +3554,7 @@
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"dashdash": {
@@ -3563,7 +3563,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"data-urls": {
@@ -3572,9 +3572,9 @@
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0"
+				"abab": "2.0.1",
+				"whatwg-mimetype": "2.3.0",
+				"whatwg-url": "7.0.0"
 			},
 			"dependencies": {
 				"whatwg-url": {
@@ -3583,9 +3583,9 @@
 					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
 					"dev": true,
 					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
+						"lodash.sortby": "4.7.0",
+						"tr46": "1.0.1",
+						"webidl-conversions": "4.0.2"
 					}
 				}
 			}
@@ -3617,8 +3617,8 @@
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
+				"decamelize": "1.2.0",
+				"map-obj": "1.0.1"
 			},
 			"dependencies": {
 				"map-obj": {
@@ -3665,7 +3665,7 @@
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 			"dev": true,
 			"requires": {
-				"object-keys": "^1.0.12"
+				"object-keys": "1.1.1"
 			}
 		},
 		"define-property": {
@@ -3674,8 +3674,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -3684,7 +3684,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -3693,7 +3693,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -3702,9 +3702,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -3749,7 +3749,7 @@
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 			"dev": true,
 			"requires": {
-				"path-type": "^4.0.0"
+				"path-type": "4.0.0"
 			},
 			"dependencies": {
 				"path-type": {
@@ -3766,7 +3766,7 @@
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2"
+				"esutils": "2.0.2"
 			}
 		},
 		"domexception": {
@@ -3775,7 +3775,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"dot-prop": {
@@ -3784,7 +3784,7 @@
 			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
 			"dev": true,
 			"requires": {
-				"is-obj": "^1.0.0"
+				"is-obj": "1.0.1"
 			}
 		},
 		"duplexer2": {
@@ -3793,7 +3793,7 @@
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.2"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"ecc-jsbn": {
@@ -3802,8 +3802,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"dev": true,
 			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"emoji-regex": {
@@ -3818,7 +3818,7 @@
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"dev": true,
 			"requires": {
-				"once": "^1.4.0"
+				"once": "1.4.0"
 			}
 		},
 		"error-ex": {
@@ -3827,7 +3827,7 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -3836,12 +3836,12 @@
 			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.2.0",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"is-callable": "^1.1.4",
-				"is-regex": "^1.0.4",
-				"object-keys": "^1.0.12"
+				"es-to-primitive": "1.2.0",
+				"function-bind": "1.1.1",
+				"has": "1.0.3",
+				"is-callable": "1.1.4",
+				"is-regex": "1.0.4",
+				"object-keys": "1.1.1"
 			}
 		},
 		"es-to-primitive": {
@@ -3850,9 +3850,9 @@
 			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
+				"is-callable": "1.1.4",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.2"
 			}
 		},
 		"es6-promise": {
@@ -3867,7 +3867,7 @@
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"dev": true,
 			"requires": {
-				"es6-promise": "^4.0.3"
+				"es6-promise": "4.2.8"
 			}
 		},
 		"escape-string-regexp": {
@@ -3882,11 +3882,11 @@
 			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
 			"dev": true,
 			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -3910,43 +3910,43 @@
 			"integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.10.0",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.5",
-				"debug": "^4.0.1",
-				"doctrine": "^3.0.0",
-				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.4.3",
-				"eslint-visitor-keys": "^1.1.0",
-				"espree": "^6.1.2",
-				"esquery": "^1.0.1",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^5.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
-				"globals": "^12.1.0",
-				"ignore": "^4.0.6",
-				"import-fresh": "^3.0.0",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^7.0.0",
-				"is-glob": "^4.0.0",
-				"js-yaml": "^3.13.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.14",
-				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.3",
-				"progress": "^2.0.0",
-				"regexpp": "^2.0.1",
-				"semver": "^6.1.2",
-				"strip-ansi": "^5.2.0",
-				"strip-json-comments": "^3.0.1",
-				"table": "^5.2.3",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"@babel/code-frame": "7.5.5",
+				"ajv": "6.10.2",
+				"chalk": "2.3.1",
+				"cross-spawn": "6.0.5",
+				"debug": "4.1.1",
+				"doctrine": "3.0.0",
+				"eslint-scope": "5.0.0",
+				"eslint-utils": "1.4.3",
+				"eslint-visitor-keys": "1.1.0",
+				"espree": "6.1.2",
+				"esquery": "1.0.1",
+				"esutils": "2.0.2",
+				"file-entry-cache": "5.0.1",
+				"functional-red-black-tree": "1.0.1",
+				"glob-parent": "5.0.0",
+				"globals": "12.3.0",
+				"ignore": "4.0.6",
+				"import-fresh": "3.1.0",
+				"imurmurhash": "0.1.4",
+				"inquirer": "7.0.1",
+				"is-glob": "4.0.1",
+				"js-yaml": "3.13.1",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.15",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.3",
+				"progress": "2.0.3",
+				"regexpp": "2.0.1",
+				"semver": "6.3.0",
+				"strip-ansi": "5.2.0",
+				"strip-json-comments": "3.0.1",
+				"table": "5.4.6",
+				"text-table": "0.2.0",
+				"v8-compile-cache": "2.1.0"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -3955,7 +3955,7 @@
 					"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
 					"dev": true,
 					"requires": {
-						"type-fest": "^0.8.1"
+						"type-fest": "0.8.1"
 					}
 				},
 				"ansi-regex": {
@@ -3970,7 +3970,7 @@
 					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^3.1.0"
+						"restore-cursor": "3.1.0"
 					}
 				},
 				"debug": {
@@ -3979,7 +3979,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"emoji-regex": {
@@ -3994,8 +3994,8 @@
 					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
+						"esrecurse": "4.2.1",
+						"estraverse": "4.2.0"
 					}
 				},
 				"eslint-utils": {
@@ -4004,7 +4004,7 @@
 					"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 					"dev": true,
 					"requires": {
-						"eslint-visitor-keys": "^1.1.0"
+						"eslint-visitor-keys": "1.1.0"
 					}
 				},
 				"eslint-visitor-keys": {
@@ -4019,7 +4019,7 @@
 					"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5"
+						"escape-string-regexp": "1.0.5"
 					}
 				},
 				"globals": {
@@ -4028,7 +4028,7 @@
 					"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
 					"dev": true,
 					"requires": {
-						"type-fest": "^0.8.1"
+						"type-fest": "0.8.1"
 					}
 				},
 				"ignore": {
@@ -4043,19 +4043,19 @@
 					"integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^2.4.2",
-						"cli-cursor": "^3.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^3.0.0",
-						"lodash": "^4.17.15",
+						"ansi-escapes": "4.3.0",
+						"chalk": "2.4.2",
+						"cli-cursor": "3.1.0",
+						"cli-width": "2.2.0",
+						"external-editor": "3.1.0",
+						"figures": "3.1.0",
+						"lodash": "4.17.15",
 						"mute-stream": "0.0.8",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.5.3",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^5.1.0",
-						"through": "^2.3.6"
+						"run-async": "2.3.0",
+						"rxjs": "6.5.4",
+						"string-width": "4.2.0",
+						"strip-ansi": "5.2.0",
+						"through": "2.3.8"
 					},
 					"dependencies": {
 						"chalk": {
@@ -4064,9 +4064,9 @@
 							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 							"dev": true,
 							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
+								"ansi-styles": "3.2.1",
+								"escape-string-regexp": "1.0.5",
+								"supports-color": "5.5.0"
 							}
 						}
 					}
@@ -4101,7 +4101,7 @@
 					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^2.1.0"
+						"mimic-fn": "2.1.0"
 					}
 				},
 				"optionator": {
@@ -4110,12 +4110,12 @@
 					"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
 					"dev": true,
 					"requires": {
-						"deep-is": "~0.1.3",
-						"fast-levenshtein": "~2.0.6",
-						"levn": "~0.3.0",
-						"prelude-ls": "~1.1.2",
-						"type-check": "~0.3.2",
-						"word-wrap": "~1.2.3"
+						"deep-is": "0.1.3",
+						"fast-levenshtein": "2.0.6",
+						"levn": "0.3.0",
+						"prelude-ls": "1.1.2",
+						"type-check": "0.3.2",
+						"word-wrap": "1.2.3"
 					}
 				},
 				"restore-cursor": {
@@ -4124,8 +4124,8 @@
 					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
 					"dev": true,
 					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
+						"onetime": "5.1.0",
+						"signal-exit": "3.0.2"
 					}
 				},
 				"rxjs": {
@@ -4134,7 +4134,7 @@
 					"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
 					"dev": true,
 					"requires": {
-						"tslib": "^1.9.0"
+						"tslib": "1.10.0"
 					}
 				},
 				"semver": {
@@ -4149,9 +4149,9 @@
 					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
 					"dev": true,
 					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
+						"emoji-regex": "8.0.0",
+						"is-fullwidth-code-point": "3.0.0",
+						"strip-ansi": "6.0.0"
 					},
 					"dependencies": {
 						"strip-ansi": {
@@ -4160,7 +4160,7 @@
 							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^5.0.0"
+								"ansi-regex": "5.0.0"
 							}
 						}
 					}
@@ -4171,7 +4171,7 @@
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "4.1.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -4202,8 +4202,8 @@
 			"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
 			}
 		},
 		"eslint-utils": {
@@ -4212,7 +4212,7 @@
 			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "1.0.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -4227,9 +4227,9 @@
 			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
-				"acorn-jsx": "^5.1.0",
-				"eslint-visitor-keys": "^1.1.0"
+				"acorn": "7.1.0",
+				"acorn-jsx": "5.1.0",
+				"eslint-visitor-keys": "1.1.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -4258,7 +4258,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"esrecurse": {
@@ -4267,7 +4267,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"estraverse": {
@@ -4294,13 +4294,13 @@
 			"integrity": "sha512-k5AR22vCt1DcfeiRixW46U5tMLtBg44ssdJM9PiXw3D8Bn5qyxFCSnKY/eR22y+ctFDGPqafpaXg2G4Emyua4A==",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^6.0.0",
-				"get-stream": "^4.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "6.0.5",
+				"get-stream": "4.1.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"exit": {
@@ -4315,13 +4315,13 @@
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.3.3",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"posix-character-classes": "^0.1.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"posix-character-classes": "0.1.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -4330,7 +4330,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -4339,7 +4339,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -4350,7 +4350,7 @@
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"dev": true,
 			"requires": {
-				"homedir-polyfill": "^1.0.1"
+				"homedir-polyfill": "1.0.3"
 			}
 		},
 		"expect": {
@@ -4359,12 +4359,12 @@
 			"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"ansi-styles": "^3.2.0",
-				"jest-get-type": "^24.9.0",
-				"jest-matcher-utils": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-regex-util": "^24.9.0"
+				"@jest/types": "24.9.0",
+				"ansi-styles": "3.2.1",
+				"jest-get-type": "24.9.0",
+				"jest-matcher-utils": "24.9.0",
+				"jest-message-util": "24.9.0",
+				"jest-regex-util": "24.9.0"
 			}
 		},
 		"extend": {
@@ -4379,8 +4379,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -4389,7 +4389,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -4400,9 +4400,9 @@
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
+				"chardet": "0.7.0",
+				"iconv-lite": "0.4.24",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -4411,14 +4411,14 @@
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"dev": true,
 			"requires": {
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"expand-brackets": "^2.1.4",
-				"extend-shallow": "^2.0.1",
-				"fragment-cache": "^0.2.1",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"array-unique": "0.3.2",
+				"define-property": "1.0.0",
+				"expand-brackets": "2.1.4",
+				"extend-shallow": "2.0.1",
+				"fragment-cache": "0.2.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -4427,7 +4427,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"extend-shallow": {
@@ -4436,7 +4436,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -4445,7 +4445,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -4454,7 +4454,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -4463,9 +4463,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -4488,12 +4488,12 @@
 			"integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "^2.0.1",
-				"@nodelib/fs.walk": "^1.2.1",
-				"glob-parent": "^5.0.0",
-				"is-glob": "^4.0.1",
-				"merge2": "^1.2.3",
-				"micromatch": "^4.0.2"
+				"@nodelib/fs.stat": "2.0.1",
+				"@nodelib/fs.walk": "1.2.2",
+				"glob-parent": "5.0.0",
+				"is-glob": "4.0.1",
+				"merge2": "1.2.3",
+				"micromatch": "4.0.2"
 			},
 			"dependencies": {
 				"braces": {
@@ -4502,7 +4502,7 @@
 					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 					"dev": true,
 					"requires": {
-						"fill-range": "^7.0.1"
+						"fill-range": "7.0.1"
 					}
 				},
 				"fill-range": {
@@ -4511,7 +4511,7 @@
 					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
 					"dev": true,
 					"requires": {
-						"to-regex-range": "^5.0.1"
+						"to-regex-range": "5.0.1"
 					}
 				},
 				"is-number": {
@@ -4526,8 +4526,8 @@
 					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
 					"dev": true,
 					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
+						"braces": "3.0.2",
+						"picomatch": "2.0.7"
 					}
 				},
 				"to-regex-range": {
@@ -4536,7 +4536,7 @@
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"dev": true,
 					"requires": {
-						"is-number": "^7.0.0"
+						"is-number": "7.0.0"
 					}
 				}
 			}
@@ -4559,7 +4559,7 @@
 			"integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
 			"dev": true,
 			"requires": {
-				"reusify": "^1.0.0"
+				"reusify": "1.0.4"
 			}
 		},
 		"fb-watchman": {
@@ -4568,7 +4568,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.1.0"
 			}
 		},
 		"figures": {
@@ -4577,7 +4577,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -4586,7 +4586,7 @@
 			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
 			"dev": true,
 			"requires": {
-				"flat-cache": "^2.0.1"
+				"flat-cache": "2.0.1"
 			}
 		},
 		"fill-range": {
@@ -4595,10 +4595,10 @@
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
+				"extend-shallow": "2.0.1",
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1",
+				"to-regex-range": "2.1.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -4607,7 +4607,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -4618,8 +4618,8 @@
 			"integrity": "sha512-8MWIBRgJi/WpjjfVXumjPKCtmQ10B+fjx6zmSA+770GMJirLhWIzg8l763rhjl9xaeaHbnxPNRQKq2mgMhr+aw==",
 			"dev": true,
 			"requires": {
-				"findup-sync": "^3.0.0",
-				"merge": "^1.2.1"
+				"findup-sync": "3.0.0",
+				"merge": "1.2.1"
 			}
 		},
 		"find-root": {
@@ -4634,7 +4634,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"findup-sync": {
@@ -4643,10 +4643,10 @@
 			"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
 			"dev": true,
 			"requires": {
-				"detect-file": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"micromatch": "^3.0.4",
-				"resolve-dir": "^1.0.1"
+				"detect-file": "1.0.0",
+				"is-glob": "4.0.1",
+				"micromatch": "3.1.10",
+				"resolve-dir": "1.0.1"
 			}
 		},
 		"flat-cache": {
@@ -4655,7 +4655,7 @@
 			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
 			"dev": true,
 			"requires": {
-				"flatted": "^2.0.0",
+				"flatted": "2.0.1",
 				"rimraf": "2.6.3",
 				"write": "1.0.3"
 			}
@@ -4684,9 +4684,9 @@
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.8",
+				"mime-types": "2.1.24"
 			}
 		},
 		"fragment-cache": {
@@ -4695,7 +4695,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"from2": {
@@ -4704,8 +4704,8 @@
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0"
+				"inherits": "2.0.4",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"fs-extra": {
@@ -4713,9 +4713,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
 			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
 			"requires": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"graceful-fs": "4.2.0",
+				"jsonfile": "4.0.0",
+				"universalify": "0.1.2"
 			}
 		},
 		"fs.realpath": {
@@ -4731,8 +4731,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.12.1",
-				"node-pre-gyp": "^0.12.0"
+				"nan": "2.14.0",
+				"node-pre-gyp": "0.12.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -4744,8 +4744,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4759,23 +4758,21 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -4788,20 +4785,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4815,7 +4809,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.1"
 					}
 				},
 				"deep-extend": {
@@ -4842,7 +4836,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.3.5"
 					}
 				},
 				"fs.realpath": {
@@ -4857,14 +4851,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.3"
 					}
 				},
 				"glob": {
@@ -4873,12 +4867,12 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-unicode": {
@@ -4893,7 +4887,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"ignore-walk": {
@@ -4902,7 +4896,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"inflight": {
@@ -4911,15 +4905,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4931,9 +4924,8 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -4946,25 +4938,22 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.2",
+						"yallist": "3.0.3"
 					}
 				},
 				"minizlib": {
@@ -4973,14 +4962,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.3.5"
 					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4997,9 +4985,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^4.1.0",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
+						"debug": "4.1.1",
+						"iconv-lite": "0.4.24",
+						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -5008,16 +4996,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.3.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.4.1",
+						"npmlog": "4.1.2",
+						"rc": "1.2.8",
+						"rimraf": "2.6.3",
+						"semver": "5.7.0",
+						"tar": "4.4.8"
 					}
 				},
 				"nopt": {
@@ -5026,8 +5014,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"npm-bundled": {
@@ -5042,8 +5030,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.6"
 					}
 				},
 				"npmlog": {
@@ -5052,17 +5040,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.5",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5074,9 +5061,8 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -5097,8 +5083,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -5119,10 +5105,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.6.0",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -5139,13 +5125,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
@@ -5154,14 +5140,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.1.3"
+						"glob": "7.1.3"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5197,11 +5182,10 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -5210,16 +5194,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -5234,13 +5217,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
+						"chownr": "1.1.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.3.5",
+						"minizlib": "1.2.1",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.2",
+						"yallist": "3.0.3"
 					}
 				},
 				"util-deprecate": {
@@ -5255,20 +5238,18 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2 || 2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -5302,7 +5283,7 @@
 			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 			"dev": true,
 			"requires": {
-				"pump": "^3.0.0"
+				"pump": "3.0.0"
 			}
 		},
 		"get-value": {
@@ -5317,7 +5298,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"git-raw-commits": {
@@ -5326,11 +5307,11 @@
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
 			"dev": true,
 			"requires": {
-				"dargs": "^4.0.1",
-				"lodash.template": "^4.0.2",
-				"meow": "^4.0.0",
-				"split2": "^2.0.0",
-				"through2": "^2.0.0"
+				"dargs": "4.1.0",
+				"lodash.template": "4.5.0",
+				"meow": "4.0.1",
+				"split2": "2.2.0",
+				"through2": "2.0.5"
 			},
 			"dependencies": {
 				"meow": {
@@ -5339,15 +5320,15 @@
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist": "^1.1.3",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0"
+						"camelcase-keys": "4.2.0",
+						"decamelize-keys": "1.1.0",
+						"loud-rejection": "1.6.0",
+						"minimist": "1.2.0",
+						"minimist-options": "3.0.2",
+						"normalize-package-data": "2.5.0",
+						"read-pkg-up": "3.0.0",
+						"redent": "2.0.0",
+						"trim-newlines": "2.0.0"
 					}
 				}
 			}
@@ -5358,12 +5339,12 @@
 			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.4",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-parent": {
@@ -5372,7 +5353,7 @@
 			"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
 			"dev": true,
 			"requires": {
-				"is-glob": "^4.0.1"
+				"is-glob": "4.0.1"
 			}
 		},
 		"global-dirs": {
@@ -5381,7 +5362,7 @@
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 			"dev": true,
 			"requires": {
-				"ini": "^1.3.4"
+				"ini": "1.3.5"
 			}
 		},
 		"global-modules": {
@@ -5390,9 +5371,9 @@
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
 			"dev": true,
 			"requires": {
-				"global-prefix": "^1.0.1",
-				"is-windows": "^1.0.1",
-				"resolve-dir": "^1.0.0"
+				"global-prefix": "1.0.2",
+				"is-windows": "1.0.2",
+				"resolve-dir": "1.0.1"
 			}
 		},
 		"global-prefix": {
@@ -5401,11 +5382,11 @@
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.2",
-				"homedir-polyfill": "^1.0.1",
-				"ini": "^1.3.4",
-				"is-windows": "^1.0.1",
-				"which": "^1.2.14"
+				"expand-tilde": "2.0.2",
+				"homedir-polyfill": "1.0.3",
+				"ini": "1.3.5",
+				"is-windows": "1.0.2",
+				"which": "1.3.1"
 			}
 		},
 		"globals": {
@@ -5420,14 +5401,14 @@
 			"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
 			"dev": true,
 			"requires": {
-				"@types/glob": "^7.1.1",
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.0.3",
-				"glob": "^7.1.3",
-				"ignore": "^5.1.1",
-				"merge2": "^1.2.3",
-				"slash": "^3.0.0"
+				"@types/glob": "7.1.1",
+				"array-union": "2.1.0",
+				"dir-glob": "3.0.1",
+				"fast-glob": "3.0.4",
+				"glob": "7.1.4",
+				"ignore": "5.1.2",
+				"merge2": "1.2.3",
+				"slash": "3.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -5447,10 +5428,10 @@
 			"integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
 			"dev": true,
 			"requires": {
-				"neo-async": "^2.6.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
+				"neo-async": "2.6.1",
+				"optimist": "0.6.1",
+				"source-map": "0.6.1",
+				"uglify-js": "3.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -5473,8 +5454,8 @@
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
+				"ajv": "6.10.2",
+				"har-schema": "2.0.0"
 			}
 		},
 		"has": {
@@ -5483,7 +5464,7 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-flag": {
@@ -5504,9 +5485,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			}
 		},
 		"has-values": {
@@ -5515,8 +5496,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5525,7 +5506,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5536,7 +5517,7 @@
 			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
 			"dev": true,
 			"requires": {
-				"parse-passwd": "^1.0.0"
+				"parse-passwd": "1.0.0"
 			}
 		},
 		"hosted-git-info": {
@@ -5551,7 +5532,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "1.0.5"
 			}
 		},
 		"http-proxy-agent": {
@@ -5560,7 +5541,7 @@
 			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
 			"dev": true,
 			"requires": {
-				"agent-base": "4",
+				"agent-base": "4.3.0",
 				"debug": "3.1.0"
 			},
 			"dependencies": {
@@ -5581,9 +5562,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.16.1"
 			}
 		},
 		"https-proxy-agent": {
@@ -5592,8 +5573,8 @@
 			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
+				"agent-base": "4.3.0",
+				"debug": "3.2.6"
 			},
 			"dependencies": {
 				"debug": {
@@ -5602,7 +5583,7 @@
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -5619,7 +5600,7 @@
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"ignore": {
@@ -5634,7 +5615,7 @@
 			"integrity": "sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==",
 			"dev": true,
 			"requires": {
-				"minimatch": "^3.0.4"
+				"minimatch": "3.0.4"
 			}
 		},
 		"import-fresh": {
@@ -5643,8 +5624,8 @@
 			"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
 			"dev": true,
 			"requires": {
-				"parent-module": "^1.0.0",
-				"resolve-from": "^4.0.0"
+				"parent-module": "1.0.1",
+				"resolve-from": "4.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -5661,7 +5642,7 @@
 			"integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^5.0.0"
+				"resolve-from": "5.0.0"
 			}
 		},
 		"import-local": {
@@ -5670,8 +5651,8 @@
 			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^3.0.0",
-				"resolve-cwd": "^2.0.0"
+				"pkg-dir": "3.0.0",
+				"resolve-cwd": "2.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -5692,8 +5673,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -5714,19 +5695,19 @@
 			"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^3.0.0",
-				"figures": "^2.0.0",
-				"lodash": "^4.17.10",
+				"ansi-escapes": "3.2.0",
+				"chalk": "2.3.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "3.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.15",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rxjs": "^6.1.0",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rxjs": "6.5.2",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			}
 		},
 		"interpret": {
@@ -5741,8 +5722,8 @@
 			"integrity": "sha512-cbDhb8qlxKMxPBk/QxTtYg1DQ4CwXmadu7quG3B7nrJsgSncEreF2kwWKZFdnjc/lSNNIkFPsjI7SM0Cx/QXPw==",
 			"dev": true,
 			"requires": {
-				"from2": "^2.3.0",
-				"p-is-promise": "^2.0.0"
+				"from2": "2.3.0",
+				"p-is-promise": "2.1.0"
 			}
 		},
 		"invariant": {
@@ -5751,7 +5732,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.4.0"
 			}
 		},
 		"is-accessor-descriptor": {
@@ -5760,7 +5741,7 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5769,7 +5750,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5798,7 +5779,7 @@
 			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^2.0.0"
+				"ci-info": "2.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -5807,7 +5788,7 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5816,7 +5797,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5833,9 +5814,9 @@
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5882,7 +5863,7 @@
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^2.1.1"
+				"is-extglob": "2.1.1"
 			}
 		},
 		"is-number": {
@@ -5891,7 +5872,7 @@
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5900,7 +5881,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5923,7 +5904,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"is-promise": {
@@ -5938,7 +5919,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.3"
 			}
 		},
 		"is-stream": {
@@ -5959,7 +5940,7 @@
 			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
 			"dev": true,
 			"requires": {
-				"has-symbols": "^1.0.0"
+				"has-symbols": "1.0.0"
 			}
 		},
 		"is-text-path": {
@@ -5968,7 +5949,7 @@
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
-				"text-extensions": "^1.0.0"
+				"text-extensions": "1.9.0"
 			}
 		},
 		"is-typedarray": {
@@ -6025,11 +6006,11 @@
 			"integrity": "sha512-1RmmAXHl5+cqTZ9dRr861xWy0Gkc9TWTEklgjKv+nhlB1dY1NmGBV8b20jTWRL5cPGpOIXkz84kEcDBM8Nc0cw==",
 			"dev": true,
 			"requires": {
-				"lodash.capitalize": "^4.2.1",
-				"lodash.escaperegexp": "^4.1.2",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.uniqby": "^4.7.0"
+				"lodash.capitalize": "4.2.1",
+				"lodash.escaperegexp": "4.1.2",
+				"lodash.isplainobject": "4.0.6",
+				"lodash.isstring": "4.0.1",
+				"lodash.uniqby": "4.7.0"
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -6044,13 +6025,13 @@
 			"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 			"dev": true,
 			"requires": {
-				"@babel/generator": "^7.4.0",
-				"@babel/parser": "^7.4.3",
-				"@babel/template": "^7.4.0",
-				"@babel/traverse": "^7.4.3",
-				"@babel/types": "^7.4.0",
-				"istanbul-lib-coverage": "^2.0.5",
-				"semver": "^6.0.0"
+				"@babel/generator": "7.5.5",
+				"@babel/parser": "7.5.5",
+				"@babel/template": "7.4.4",
+				"@babel/traverse": "7.5.5",
+				"@babel/types": "7.5.5",
+				"istanbul-lib-coverage": "2.0.5",
+				"semver": "6.3.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -6067,9 +6048,9 @@
 			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"supports-color": "^6.1.0"
+				"istanbul-lib-coverage": "2.0.5",
+				"make-dir": "2.1.0",
+				"supports-color": "6.1.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -6078,7 +6059,7 @@
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -6089,11 +6070,11 @@
 			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
 			"dev": true,
 			"requires": {
-				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"rimraf": "^2.6.3",
-				"source-map": "^0.6.1"
+				"debug": "4.1.1",
+				"istanbul-lib-coverage": "2.0.5",
+				"make-dir": "2.1.0",
+				"rimraf": "2.6.3",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -6102,7 +6083,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -6125,7 +6106,7 @@
 			"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.1.2"
+				"handlebars": "4.5.3"
 			}
 		},
 		"java-properties": {
@@ -6140,8 +6121,8 @@
 			"integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
 			"dev": true,
 			"requires": {
-				"import-local": "^2.0.0",
-				"jest-cli": "^24.9.0"
+				"import-local": "2.0.0",
+				"jest-cli": "24.9.0"
 			},
 			"dependencies": {
 				"jest-cli": {
@@ -6150,19 +6131,19 @@
 					"integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^24.9.0",
-						"@jest/test-result": "^24.9.0",
-						"@jest/types": "^24.9.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"import-local": "^2.0.0",
-						"is-ci": "^2.0.0",
-						"jest-config": "^24.9.0",
-						"jest-util": "^24.9.0",
-						"jest-validate": "^24.9.0",
-						"prompts": "^2.0.1",
-						"realpath-native": "^1.1.0",
-						"yargs": "^13.3.0"
+						"@jest/core": "24.9.0",
+						"@jest/test-result": "24.9.0",
+						"@jest/types": "24.9.0",
+						"chalk": "2.3.1",
+						"exit": "0.1.2",
+						"import-local": "2.0.0",
+						"is-ci": "2.0.0",
+						"jest-config": "24.9.0",
+						"jest-util": "24.9.0",
+						"jest-validate": "24.9.0",
+						"prompts": "2.2.1",
+						"realpath-native": "1.1.0",
+						"yargs": "13.3.0"
 					}
 				}
 			}
@@ -6173,9 +6154,9 @@
 			"integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"execa": "^1.0.0",
-				"throat": "^4.0.0"
+				"@jest/types": "24.9.0",
+				"execa": "1.0.0",
+				"throat": "4.1.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -6184,11 +6165,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.5",
+						"path-key": "2.0.1",
+						"semver": "5.7.1",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					}
 				},
 				"execa": {
@@ -6197,13 +6178,13 @@
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "6.0.5",
+						"get-stream": "4.1.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"get-stream": {
@@ -6212,7 +6193,7 @@
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"pump": "3.0.0"
 					}
 				},
 				"semver": {
@@ -6229,23 +6210,23 @@
 			"integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"babel-jest": "^24.9.0",
-				"chalk": "^2.0.1",
-				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^24.9.0",
-				"jest-environment-node": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"jest-jasmine2": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"micromatch": "^3.1.10",
-				"pretty-format": "^24.9.0",
-				"realpath-native": "^1.1.0"
+				"@babel/core": "7.5.5",
+				"@jest/test-sequencer": "24.9.0",
+				"@jest/types": "24.9.0",
+				"babel-jest": "24.9.0",
+				"chalk": "2.3.1",
+				"glob": "7.1.4",
+				"jest-environment-jsdom": "24.9.0",
+				"jest-environment-node": "24.9.0",
+				"jest-get-type": "24.9.0",
+				"jest-jasmine2": "24.9.0",
+				"jest-regex-util": "24.9.0",
+				"jest-resolve": "24.9.0",
+				"jest-util": "24.9.0",
+				"jest-validate": "24.9.0",
+				"micromatch": "3.1.10",
+				"pretty-format": "24.9.0",
+				"realpath-native": "1.1.0"
 			}
 		},
 		"jest-diff": {
@@ -6254,10 +6235,10 @@
 			"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff-sequences": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"chalk": "2.3.1",
+				"diff-sequences": "24.9.0",
+				"jest-get-type": "24.9.0",
+				"pretty-format": "24.9.0"
 			}
 		},
 		"jest-docblock": {
@@ -6266,7 +6247,7 @@
 			"integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "2.1.0"
 			},
 			"dependencies": {
 				"detect-newline": {
@@ -6283,11 +6264,11 @@
 			"integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
-				"jest-get-type": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"@jest/types": "24.9.0",
+				"chalk": "2.3.1",
+				"jest-get-type": "24.9.0",
+				"jest-util": "24.9.0",
+				"pretty-format": "24.9.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -6296,12 +6277,12 @@
 			"integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"jest-mock": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jsdom": "^11.5.1"
+				"@jest/environment": "24.9.0",
+				"@jest/fake-timers": "24.9.0",
+				"@jest/types": "24.9.0",
+				"jest-mock": "24.9.0",
+				"jest-util": "24.9.0",
+				"jsdom": "11.12.0"
 			}
 		},
 		"jest-environment-node": {
@@ -6310,11 +6291,11 @@
 			"integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"jest-mock": "^24.9.0",
-				"jest-util": "^24.9.0"
+				"@jest/environment": "24.9.0",
+				"@jest/fake-timers": "24.9.0",
+				"@jest/types": "24.9.0",
+				"jest-mock": "24.9.0",
+				"jest-util": "24.9.0"
 			}
 		},
 		"jest-get-type": {
@@ -6329,18 +6310,18 @@
 			"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"anymatch": "^2.0.0",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.7",
-				"graceful-fs": "^4.1.15",
-				"invariant": "^2.2.4",
-				"jest-serializer": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.9.0",
-				"micromatch": "^3.1.10",
-				"sane": "^4.0.3",
-				"walker": "^1.0.7"
+				"@jest/types": "24.9.0",
+				"anymatch": "2.0.0",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.2.9",
+				"graceful-fs": "4.2.0",
+				"invariant": "2.2.4",
+				"jest-serializer": "24.9.0",
+				"jest-util": "24.9.0",
+				"jest-worker": "24.9.0",
+				"micromatch": "3.1.10",
+				"sane": "4.1.0",
+				"walker": "1.0.7"
 			}
 		},
 		"jest-jasmine2": {
@@ -6349,22 +6330,22 @@
 			"integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
-				"co": "^4.6.0",
-				"expect": "^24.9.0",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^24.9.0",
-				"jest-matcher-utils": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"pretty-format": "^24.9.0",
-				"throat": "^4.0.0"
+				"@babel/traverse": "7.5.5",
+				"@jest/environment": "24.9.0",
+				"@jest/test-result": "24.9.0",
+				"@jest/types": "24.9.0",
+				"chalk": "2.3.1",
+				"co": "4.6.0",
+				"expect": "24.9.0",
+				"is-generator-fn": "2.1.0",
+				"jest-each": "24.9.0",
+				"jest-matcher-utils": "24.9.0",
+				"jest-message-util": "24.9.0",
+				"jest-runtime": "24.9.0",
+				"jest-snapshot": "24.9.0",
+				"jest-util": "24.9.0",
+				"pretty-format": "24.9.0",
+				"throat": "4.1.0"
 			}
 		},
 		"jest-leak-detector": {
@@ -6373,8 +6354,8 @@
 			"integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
 			"dev": true,
 			"requires": {
-				"jest-get-type": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"jest-get-type": "24.9.0",
+				"pretty-format": "24.9.0"
 			}
 		},
 		"jest-matcher-utils": {
@@ -6383,10 +6364,10 @@
 			"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-diff": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"chalk": "2.3.1",
+				"jest-diff": "24.9.0",
+				"jest-get-type": "24.9.0",
+				"pretty-format": "24.9.0"
 			}
 		},
 		"jest-message-util": {
@@ -6395,14 +6376,14 @@
 			"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/stack-utils": "^1.0.1",
-				"chalk": "^2.0.1",
-				"micromatch": "^3.1.10",
-				"slash": "^2.0.0",
-				"stack-utils": "^1.0.1"
+				"@babel/code-frame": "7.5.5",
+				"@jest/test-result": "24.9.0",
+				"@jest/types": "24.9.0",
+				"@types/stack-utils": "1.0.1",
+				"chalk": "2.3.1",
+				"micromatch": "3.1.10",
+				"slash": "2.0.0",
+				"stack-utils": "1.0.2"
 			},
 			"dependencies": {
 				"slash": {
@@ -6419,7 +6400,7 @@
 			"integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0"
+				"@jest/types": "24.9.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -6440,11 +6421,11 @@
 			"integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"browser-resolve": "^1.11.3",
-				"chalk": "^2.0.1",
-				"jest-pnp-resolver": "^1.2.1",
-				"realpath-native": "^1.1.0"
+				"@jest/types": "24.9.0",
+				"browser-resolve": "1.11.3",
+				"chalk": "2.3.1",
+				"jest-pnp-resolver": "1.2.1",
+				"realpath-native": "1.1.0"
 			}
 		},
 		"jest-resolve-dependencies": {
@@ -6453,9 +6434,9 @@
 			"integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-snapshot": "^24.9.0"
+				"@jest/types": "24.9.0",
+				"jest-regex-util": "24.9.0",
+				"jest-snapshot": "24.9.0"
 			}
 		},
 		"jest-runner": {
@@ -6464,25 +6445,25 @@
 			"integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.4.2",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.9.0",
-				"jest-docblock": "^24.3.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-jasmine2": "^24.9.0",
-				"jest-leak-detector": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.6.0",
-				"source-map-support": "^0.5.6",
-				"throat": "^4.0.0"
+				"@jest/console": "24.9.0",
+				"@jest/environment": "24.9.0",
+				"@jest/test-result": "24.9.0",
+				"@jest/types": "24.9.0",
+				"chalk": "2.4.2",
+				"exit": "0.1.2",
+				"graceful-fs": "4.2.0",
+				"jest-config": "24.9.0",
+				"jest-docblock": "24.9.0",
+				"jest-haste-map": "24.9.0",
+				"jest-jasmine2": "24.9.0",
+				"jest-leak-detector": "24.9.0",
+				"jest-message-util": "24.9.0",
+				"jest-resolve": "24.9.0",
+				"jest-runtime": "24.9.0",
+				"jest-util": "24.9.0",
+				"jest-worker": "24.9.0",
+				"source-map-support": "0.5.13",
+				"throat": "4.1.0"
 			},
 			"dependencies": {
 				"chalk": {
@@ -6491,9 +6472,9 @@
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				}
 			}
@@ -6504,29 +6485,29 @@
 			"integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.9.0",
-				"@jest/source-map": "^24.3.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/yargs": "^13.0.0",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-mock": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"realpath-native": "^1.1.0",
-				"slash": "^2.0.0",
-				"strip-bom": "^3.0.0",
-				"yargs": "^13.3.0"
+				"@jest/console": "24.9.0",
+				"@jest/environment": "24.9.0",
+				"@jest/source-map": "24.9.0",
+				"@jest/transform": "24.9.0",
+				"@jest/types": "24.9.0",
+				"@types/yargs": "13.0.2",
+				"chalk": "2.3.1",
+				"exit": "0.1.2",
+				"glob": "7.1.4",
+				"graceful-fs": "4.2.0",
+				"jest-config": "24.9.0",
+				"jest-haste-map": "24.9.0",
+				"jest-message-util": "24.9.0",
+				"jest-mock": "24.9.0",
+				"jest-regex-util": "24.9.0",
+				"jest-resolve": "24.9.0",
+				"jest-snapshot": "24.9.0",
+				"jest-util": "24.9.0",
+				"jest-validate": "24.9.0",
+				"realpath-native": "1.1.0",
+				"slash": "2.0.0",
+				"strip-bom": "3.0.0",
+				"yargs": "13.3.0"
 			},
 			"dependencies": {
 				"slash": {
@@ -6549,19 +6530,19 @@
 			"integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
-				"expect": "^24.9.0",
-				"jest-diff": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"jest-matcher-utils": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^24.9.0",
-				"semver": "^6.2.0"
+				"@babel/types": "7.5.5",
+				"@jest/types": "24.9.0",
+				"chalk": "2.3.1",
+				"expect": "24.9.0",
+				"jest-diff": "24.9.0",
+				"jest-get-type": "24.9.0",
+				"jest-matcher-utils": "24.9.0",
+				"jest-message-util": "24.9.0",
+				"jest-resolve": "24.9.0",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "24.9.0",
+				"semver": "6.3.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -6578,18 +6559,18 @@
 			"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.9.0",
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/source-map": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"callsites": "^3.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.15",
-				"is-ci": "^2.0.0",
-				"mkdirp": "^0.5.1",
-				"slash": "^2.0.0",
-				"source-map": "^0.6.0"
+				"@jest/console": "24.9.0",
+				"@jest/fake-timers": "24.9.0",
+				"@jest/source-map": "24.9.0",
+				"@jest/test-result": "24.9.0",
+				"@jest/types": "24.9.0",
+				"callsites": "3.1.0",
+				"chalk": "2.3.1",
+				"graceful-fs": "4.2.0",
+				"is-ci": "2.0.0",
+				"mkdirp": "0.5.1",
+				"slash": "2.0.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"slash": {
@@ -6612,12 +6593,12 @@
 			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"camelcase": "^5.3.1",
-				"chalk": "^2.0.1",
-				"jest-get-type": "^24.9.0",
-				"leven": "^3.1.0",
-				"pretty-format": "^24.9.0"
+				"@jest/types": "24.9.0",
+				"camelcase": "5.3.1",
+				"chalk": "2.3.1",
+				"jest-get-type": "24.9.0",
+				"leven": "3.1.0",
+				"pretty-format": "24.9.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -6634,13 +6615,13 @@
 			"integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/yargs": "^13.0.0",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"jest-util": "^24.9.0",
-				"string-length": "^2.0.0"
+				"@jest/test-result": "24.9.0",
+				"@jest/types": "24.9.0",
+				"@types/yargs": "13.0.2",
+				"ansi-escapes": "3.2.0",
+				"chalk": "2.3.1",
+				"jest-util": "24.9.0",
+				"string-length": "2.0.0"
 			}
 		},
 		"jest-worker": {
@@ -6649,8 +6630,8 @@
 			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
+				"merge-stream": "2.0.0",
+				"supports-color": "6.1.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -6659,7 +6640,7 @@
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -6676,8 +6657,8 @@
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.10",
+				"esprima": "4.0.1"
 			}
 		},
 		"jsbn": {
@@ -6692,32 +6673,32 @@
 			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"acorn": "^5.5.3",
-				"acorn-globals": "^4.1.0",
-				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": "^1.0.0",
-				"data-urls": "^1.0.0",
-				"domexception": "^1.0.1",
-				"escodegen": "^1.9.1",
-				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.3.0",
-				"nwsapi": "^2.0.7",
+				"abab": "2.0.1",
+				"acorn": "5.7.3",
+				"acorn-globals": "4.3.3",
+				"array-equal": "1.0.0",
+				"cssom": "0.3.8",
+				"cssstyle": "1.4.0",
+				"data-urls": "1.1.0",
+				"domexception": "1.0.1",
+				"escodegen": "1.12.0",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.3.0",
+				"nwsapi": "2.1.4",
 				"parse5": "4.0.0",
-				"pn": "^1.1.0",
-				"request": "^2.87.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.4",
-				"w3c-hr-time": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.1",
-				"ws": "^5.2.0",
-				"xml-name-validator": "^3.0.0"
+				"pn": "1.1.0",
+				"request": "2.88.0",
+				"request-promise-native": "1.0.7",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.4",
+				"tough-cookie": "2.5.0",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.5",
+				"whatwg-mimetype": "2.3.0",
+				"whatwg-url": "6.5.0",
+				"ws": "5.2.2",
+				"xml-name-validator": "3.0.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -6770,7 +6751,7 @@
 			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.0"
+				"minimist": "1.2.0"
 			}
 		},
 		"jsonfile": {
@@ -6778,7 +6759,7 @@
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
-				"graceful-fs": "^4.1.6"
+				"graceful-fs": "4.2.0"
 			}
 		},
 		"jsonparse": {
@@ -6829,8 +6810,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"lines-and-columns": {
@@ -6845,10 +6826,10 @@
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
+				"graceful-fs": "4.2.0",
+				"parse-json": "4.0.0",
+				"pify": "3.0.0",
+				"strip-bom": "3.0.0"
 			}
 		},
 		"locate-path": {
@@ -6857,8 +6838,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -6932,8 +6913,8 @@
 			"integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
 			"dev": true,
 			"requires": {
-				"lodash._reinterpolate": "^3.0.0",
-				"lodash.templatesettings": "^4.0.0"
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.templatesettings": "4.2.0"
 			}
 		},
 		"lodash.templatesettings": {
@@ -6942,7 +6923,7 @@
 			"integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
 			"dev": true,
 			"requires": {
-				"lodash._reinterpolate": "^3.0.0"
+				"lodash._reinterpolate": "3.0.0"
 			}
 		},
 		"lodash.toarray": {
@@ -6981,7 +6962,7 @@
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"dev": true,
 			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
+				"js-tokens": "4.0.0"
 			}
 		},
 		"loud-rejection": {
@@ -6990,8 +6971,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"macos-release": {
@@ -7006,8 +6987,8 @@
 			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
 			"dev": true,
 			"requires": {
-				"pify": "^4.0.1",
-				"semver": "^5.6.0"
+				"pify": "4.0.1",
+				"semver": "5.7.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -7036,7 +7017,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.x"
+				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
@@ -7057,7 +7038,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"meow": {
@@ -7066,15 +7047,15 @@
 			"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^4.0.0",
-				"decamelize-keys": "^1.0.0",
-				"loud-rejection": "^1.0.0",
-				"minimist-options": "^3.0.1",
-				"normalize-package-data": "^2.3.4",
-				"read-pkg-up": "^3.0.0",
-				"redent": "^2.0.0",
-				"trim-newlines": "^2.0.0",
-				"yargs-parser": "^10.0.0"
+				"camelcase-keys": "4.2.0",
+				"decamelize-keys": "1.1.0",
+				"loud-rejection": "1.6.0",
+				"minimist-options": "3.0.2",
+				"normalize-package-data": "2.5.0",
+				"read-pkg-up": "3.0.0",
+				"redent": "2.0.0",
+				"trim-newlines": "2.0.0",
+				"yargs-parser": "10.1.0"
 			}
 		},
 		"merge": {
@@ -7101,19 +7082,19 @@
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.2"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"braces": "2.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"extglob": "2.0.4",
+				"fragment-cache": "0.2.1",
+				"kind-of": "6.0.2",
+				"nanomatch": "1.2.13",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"mime": {
@@ -7149,7 +7130,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -7164,8 +7145,8 @@
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0"
+				"arrify": "1.0.1",
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"mixin-deep": {
@@ -7174,8 +7155,8 @@
 			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -7184,7 +7165,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -7237,17 +7218,17 @@
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"natural-compare": {
@@ -7280,7 +7261,7 @@
 			"integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
 			"dev": true,
 			"requires": {
-				"lodash.toarray": "^4.4.0"
+				"lodash.toarray": "4.4.0"
 			}
 		},
 		"node-fetch": {
@@ -7307,11 +7288,11 @@
 			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
 			"dev": true,
 			"requires": {
-				"growly": "^1.3.0",
-				"is-wsl": "^1.1.0",
-				"semver": "^5.5.0",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"growly": "1.3.0",
+				"is-wsl": "1.1.0",
+				"semver": "5.7.1",
+				"shellwords": "0.1.1",
+				"which": "1.3.1"
 			},
 			"dependencies": {
 				"semver": {
@@ -7328,10 +7309,10 @@
 			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"resolve": "^1.10.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.7.1",
+				"resolve": "1.11.1",
+				"semver": "5.7.0",
+				"validate-npm-package-license": "3.0.4"
 			},
 			"dependencies": {
 				"semver": {
@@ -7348,7 +7329,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"normalize-url": {
@@ -7363,129 +7344,129 @@
 			"integrity": "sha512-vTcUL4SCg3AzwInWTbqg1OIaOXlzKSS8Mb8kc5avwrJpcvevDA5J9BhYSuei+fNs3pwOp4lzA5x2FVDXACvoXA==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "^1.3.5",
-				"abbrev": "~1.1.1",
-				"ansicolors": "~0.3.2",
-				"ansistyles": "~0.1.3",
-				"aproba": "^2.0.0",
-				"archy": "~1.0.0",
-				"bin-links": "^1.1.6",
-				"bluebird": "^3.5.5",
-				"byte-size": "^5.0.1",
-				"cacache": "^12.0.3",
-				"call-limit": "^1.1.1",
-				"chownr": "^1.1.3",
-				"ci-info": "^2.0.0",
-				"cli-columns": "^3.1.2",
-				"cli-table3": "^0.5.1",
-				"cmd-shim": "^3.0.3",
-				"columnify": "~1.5.4",
-				"config-chain": "^1.1.12",
-				"debuglog": "*",
-				"detect-indent": "~5.0.0",
-				"detect-newline": "^2.1.0",
-				"dezalgo": "~1.0.3",
-				"editor": "~1.0.0",
-				"figgy-pudding": "^3.5.1",
-				"find-npm-prefix": "^1.0.2",
-				"fs-vacuum": "~1.2.10",
-				"fs-write-stream-atomic": "~1.0.10",
-				"gentle-fs": "^2.3.0",
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.3",
-				"has-unicode": "~2.0.1",
-				"hosted-git-info": "^2.8.5",
-				"iferr": "^1.0.2",
-				"imurmurhash": "*",
-				"infer-owner": "^1.0.4",
-				"inflight": "~1.0.6",
-				"inherits": "^2.0.4",
-				"ini": "^1.3.5",
-				"init-package-json": "^1.10.3",
-				"is-cidr": "^3.0.0",
-				"json-parse-better-errors": "^1.0.2",
-				"lazy-property": "~1.0.0",
-				"libcipm": "^4.0.7",
-				"libnpm": "^3.0.1",
-				"libnpmaccess": "^3.0.2",
-				"libnpmhook": "^5.0.3",
-				"libnpmorg": "^1.0.1",
-				"libnpmsearch": "^2.0.2",
-				"libnpmteam": "^1.0.2",
-				"libnpx": "^10.2.0",
-				"lock-verify": "^2.1.0",
-				"lockfile": "^1.0.4",
-				"lodash._baseindexof": "*",
-				"lodash._baseuniq": "~4.6.0",
-				"lodash._bindcallback": "*",
-				"lodash._cacheindexof": "*",
-				"lodash._createcache": "*",
-				"lodash._getnative": "*",
-				"lodash.clonedeep": "~4.5.0",
-				"lodash.restparam": "*",
-				"lodash.union": "~4.6.0",
-				"lodash.uniq": "~4.5.0",
-				"lodash.without": "~4.4.0",
-				"lru-cache": "^5.1.1",
-				"meant": "~1.0.1",
-				"mississippi": "^3.0.0",
-				"mkdirp": "~0.5.1",
-				"move-concurrently": "^1.0.1",
-				"node-gyp": "^5.0.5",
-				"nopt": "~4.0.1",
-				"normalize-package-data": "^2.5.0",
-				"npm-audit-report": "^1.3.2",
-				"npm-cache-filename": "~1.0.2",
-				"npm-install-checks": "^3.0.2",
-				"npm-lifecycle": "^3.1.4",
-				"npm-package-arg": "^6.1.1",
-				"npm-packlist": "^1.4.7",
-				"npm-pick-manifest": "^3.0.2",
-				"npm-profile": "^4.0.2",
-				"npm-registry-fetch": "^4.0.2",
-				"npm-user-validate": "~1.0.0",
-				"npmlog": "~4.1.2",
-				"once": "~1.4.0",
-				"opener": "^1.5.1",
-				"osenv": "^0.1.5",
-				"pacote": "^9.5.11",
-				"path-is-inside": "~1.0.2",
-				"promise-inflight": "~1.0.1",
-				"qrcode-terminal": "^0.12.0",
-				"query-string": "^6.8.2",
-				"qw": "~1.0.1",
-				"read": "~1.0.7",
-				"read-cmd-shim": "^1.0.5",
-				"read-installed": "~4.0.3",
-				"read-package-json": "^2.1.1",
-				"read-package-tree": "^5.3.1",
-				"readable-stream": "^3.4.0",
-				"readdir-scoped-modules": "^1.1.0",
-				"request": "^2.88.0",
-				"retry": "^0.12.0",
-				"rimraf": "^2.6.3",
-				"safe-buffer": "^5.1.2",
-				"semver": "^5.7.1",
-				"sha": "^3.0.0",
-				"slide": "~1.1.6",
-				"sorted-object": "~2.0.1",
-				"sorted-union-stream": "~2.1.3",
-				"ssri": "^6.0.1",
-				"stringify-package": "^1.0.1",
-				"tar": "^4.4.13",
-				"text-table": "~0.2.0",
-				"tiny-relative-date": "^1.3.0",
+				"JSONStream": "1.3.5",
+				"abbrev": "1.1.1",
+				"ansicolors": "0.3.2",
+				"ansistyles": "0.1.3",
+				"aproba": "2.0.0",
+				"archy": "1.0.0",
+				"bin-links": "1.1.6",
+				"bluebird": "3.5.5",
+				"byte-size": "5.0.1",
+				"cacache": "12.0.3",
+				"call-limit": "1.1.1",
+				"chownr": "1.1.3",
+				"ci-info": "2.0.0",
+				"cli-columns": "3.1.2",
+				"cli-table3": "0.5.1",
+				"cmd-shim": "3.0.3",
+				"columnify": "1.5.4",
+				"config-chain": "1.1.12",
+				"debuglog": "1.0.1",
+				"detect-indent": "5.0.0",
+				"detect-newline": "2.1.0",
+				"dezalgo": "1.0.3",
+				"editor": "1.0.0",
+				"figgy-pudding": "3.5.1",
+				"find-npm-prefix": "1.0.2",
+				"fs-vacuum": "1.2.10",
+				"fs-write-stream-atomic": "1.0.10",
+				"gentle-fs": "2.3.0",
+				"glob": "7.1.4",
+				"graceful-fs": "4.2.3",
+				"has-unicode": "2.0.1",
+				"hosted-git-info": "2.8.5",
+				"iferr": "1.0.2",
+				"imurmurhash": "0.1.4",
+				"infer-owner": "1.0.4",
+				"inflight": "1.0.6",
+				"inherits": "2.0.4",
+				"ini": "1.3.5",
+				"init-package-json": "1.10.3",
+				"is-cidr": "3.0.0",
+				"json-parse-better-errors": "1.0.2",
+				"lazy-property": "1.0.0",
+				"libcipm": "4.0.7",
+				"libnpm": "3.0.1",
+				"libnpmaccess": "3.0.2",
+				"libnpmhook": "5.0.3",
+				"libnpmorg": "1.0.1",
+				"libnpmsearch": "2.0.2",
+				"libnpmteam": "1.0.2",
+				"libnpx": "10.2.0",
+				"lock-verify": "2.1.0",
+				"lockfile": "1.0.4",
+				"lodash._baseindexof": "3.1.0",
+				"lodash._baseuniq": "4.6.0",
+				"lodash._bindcallback": "3.0.1",
+				"lodash._cacheindexof": "3.0.2",
+				"lodash._createcache": "3.1.2",
+				"lodash._getnative": "3.9.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.restparam": "3.6.1",
+				"lodash.union": "4.6.0",
+				"lodash.uniq": "4.5.0",
+				"lodash.without": "4.4.0",
+				"lru-cache": "5.1.1",
+				"meant": "1.0.1",
+				"mississippi": "3.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"node-gyp": "5.0.5",
+				"nopt": "4.0.1",
+				"normalize-package-data": "2.5.0",
+				"npm-audit-report": "1.3.2",
+				"npm-cache-filename": "1.0.2",
+				"npm-install-checks": "3.0.2",
+				"npm-lifecycle": "3.1.4",
+				"npm-package-arg": "6.1.1",
+				"npm-packlist": "1.4.7",
+				"npm-pick-manifest": "3.0.2",
+				"npm-profile": "4.0.2",
+				"npm-registry-fetch": "4.0.2",
+				"npm-user-validate": "1.0.0",
+				"npmlog": "4.1.2",
+				"once": "1.4.0",
+				"opener": "1.5.1",
+				"osenv": "0.1.5",
+				"pacote": "9.5.11",
+				"path-is-inside": "1.0.2",
+				"promise-inflight": "1.0.1",
+				"qrcode-terminal": "0.12.0",
+				"query-string": "6.8.2",
+				"qw": "1.0.1",
+				"read": "1.0.7",
+				"read-cmd-shim": "1.0.5",
+				"read-installed": "4.0.3",
+				"read-package-json": "2.1.1",
+				"read-package-tree": "5.3.1",
+				"readable-stream": "3.4.0",
+				"readdir-scoped-modules": "1.1.0",
+				"request": "2.88.0",
+				"retry": "0.12.0",
+				"rimraf": "2.6.3",
+				"safe-buffer": "5.1.2",
+				"semver": "5.7.1",
+				"sha": "3.0.0",
+				"slide": "1.1.6",
+				"sorted-object": "2.0.1",
+				"sorted-union-stream": "2.1.3",
+				"ssri": "6.0.1",
+				"stringify-package": "1.0.1",
+				"tar": "4.4.13",
+				"text-table": "0.2.0",
+				"tiny-relative-date": "1.3.0",
 				"uid-number": "0.0.6",
-				"umask": "~1.1.0",
-				"unique-filename": "^1.1.1",
-				"unpipe": "~1.0.0",
-				"update-notifier": "^2.5.0",
-				"uuid": "^3.3.3",
-				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "~3.0.0",
-				"which": "^1.3.1",
-				"worker-farm": "^1.7.0",
-				"write-file-atomic": "^2.4.3"
+				"umask": "1.1.0",
+				"unique-filename": "1.1.1",
+				"unpipe": "1.0.0",
+				"update-notifier": "2.5.0",
+				"uuid": "3.3.3",
+				"validate-npm-package-license": "3.0.4",
+				"validate-npm-package-name": "3.0.0",
+				"which": "1.3.1",
+				"worker-farm": "1.7.0",
+				"write-file-atomic": "2.4.3"
 			},
 			"dependencies": {
 				"JSONStream": {
@@ -7493,8 +7474,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"jsonparse": "^1.2.0",
-						"through": ">=2.2.7 <3"
+						"jsonparse": "1.3.1",
+						"through": "2.3.8"
 					}
 				},
 				"abbrev": {
@@ -7507,7 +7488,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"es6-promisify": "^5.0.0"
+						"es6-promisify": "5.0.0"
 					}
 				},
 				"agentkeepalive": {
@@ -7515,7 +7496,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"humanize-ms": "^1.2.1"
+						"humanize-ms": "1.2.1"
 					}
 				},
 				"ajv": {
@@ -7523,10 +7504,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"co": "4.6.0",
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
 					}
 				},
 				"ansi-align": {
@@ -7534,7 +7515,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "^2.0.0"
+						"string-width": "2.1.1"
 					}
 				},
 				"ansi-regex": {
@@ -7547,7 +7528,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"ansicolors": {
@@ -7575,8 +7556,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					},
 					"dependencies": {
 						"readable-stream": {
@@ -7584,13 +7565,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.2",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"string_decoder": {
@@ -7598,7 +7579,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -7613,7 +7594,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safer-buffer": "~2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"assert-plus": {
@@ -7647,7 +7628,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"tweetnacl": "^0.14.3"
+						"tweetnacl": "0.14.5"
 					}
 				},
 				"bin-links": {
@@ -7655,12 +7636,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.3",
-						"cmd-shim": "^3.0.0",
-						"gentle-fs": "^2.3.0",
-						"graceful-fs": "^4.1.15",
-						"npm-normalize-package-bin": "^1.0.0",
-						"write-file-atomic": "^2.3.0"
+						"bluebird": "3.5.5",
+						"cmd-shim": "3.0.3",
+						"gentle-fs": "2.3.0",
+						"graceful-fs": "4.2.3",
+						"npm-normalize-package-bin": "1.0.1",
+						"write-file-atomic": "2.4.3"
 					}
 				},
 				"bluebird": {
@@ -7673,13 +7654,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-align": "^2.0.0",
-						"camelcase": "^4.0.0",
-						"chalk": "^2.0.1",
-						"cli-boxes": "^1.0.0",
-						"string-width": "^2.0.0",
-						"term-size": "^1.2.0",
-						"widest-line": "^2.0.0"
+						"ansi-align": "2.0.0",
+						"camelcase": "4.1.0",
+						"chalk": "2.4.1",
+						"cli-boxes": "1.0.0",
+						"string-width": "2.1.1",
+						"term-size": "1.2.0",
+						"widest-line": "2.0.0"
 					}
 				},
 				"brace-expansion": {
@@ -7687,7 +7668,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -7716,21 +7697,21 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.5",
-						"chownr": "^1.1.1",
-						"figgy-pudding": "^3.5.1",
-						"glob": "^7.1.4",
-						"graceful-fs": "^4.1.15",
-						"infer-owner": "^1.0.3",
-						"lru-cache": "^5.1.1",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"move-concurrently": "^1.0.1",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.3",
-						"ssri": "^6.0.1",
-						"unique-filename": "^1.1.1",
-						"y18n": "^4.0.0"
+						"bluebird": "3.5.5",
+						"chownr": "1.1.3",
+						"figgy-pudding": "3.5.1",
+						"glob": "7.1.4",
+						"graceful-fs": "4.2.3",
+						"infer-owner": "1.0.4",
+						"lru-cache": "5.1.1",
+						"mississippi": "3.0.0",
+						"mkdirp": "0.5.1",
+						"move-concurrently": "1.0.1",
+						"promise-inflight": "1.0.1",
+						"rimraf": "2.6.3",
+						"ssri": "6.0.1",
+						"unique-filename": "1.1.1",
+						"y18n": "4.0.0"
 					}
 				},
 				"call-limit": {
@@ -7758,9 +7739,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"chownr": {
@@ -7778,7 +7759,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ip-regex": "^2.1.0"
+						"ip-regex": "2.1.0"
 					}
 				},
 				"cli-boxes": {
@@ -7791,8 +7772,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "^2.0.0",
-						"strip-ansi": "^3.0.1"
+						"string-width": "2.1.1",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"cli-table3": {
@@ -7800,9 +7781,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"colors": "^1.1.2",
-						"object-assign": "^4.1.0",
-						"string-width": "^2.1.1"
+						"colors": "1.3.3",
+						"object-assign": "4.1.1",
+						"string-width": "2.1.1"
 					}
 				},
 				"cliui": {
@@ -7810,9 +7791,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -7825,7 +7806,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "3.0.0"
 							}
 						}
 					}
@@ -7840,8 +7821,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"mkdirp": "~0.5.0"
+						"graceful-fs": "4.2.3",
+						"mkdirp": "0.5.1"
 					}
 				},
 				"co": {
@@ -7859,7 +7840,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"color-name": "^1.1.1"
+						"color-name": "1.1.3"
 					}
 				},
 				"color-name": {
@@ -7878,8 +7859,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"strip-ansi": "^3.0.0",
-						"wcwidth": "^1.0.0"
+						"strip-ansi": "3.0.1",
+						"wcwidth": "1.0.1"
 					}
 				},
 				"combined-stream": {
@@ -7887,7 +7868,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"delayed-stream": "~1.0.0"
+						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
@@ -7900,10 +7881,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"buffer-from": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.2.2",
-						"typedarray": "^0.0.6"
+						"buffer-from": "1.0.0",
+						"inherits": "2.0.4",
+						"readable-stream": "2.3.6",
+						"typedarray": "0.0.6"
 					},
 					"dependencies": {
 						"readable-stream": {
@@ -7911,13 +7892,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.2",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"string_decoder": {
@@ -7925,7 +7906,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -7935,8 +7916,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ini": "^1.3.4",
-						"proto-list": "~1.2.1"
+						"ini": "1.3.5",
+						"proto-list": "1.2.4"
 					}
 				},
 				"configstore": {
@@ -7944,12 +7925,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.0",
-						"graceful-fs": "^4.1.2",
-						"make-dir": "^1.0.0",
-						"unique-string": "^1.0.0",
-						"write-file-atomic": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
+						"dot-prop": "4.2.0",
+						"graceful-fs": "4.2.3",
+						"make-dir": "1.3.0",
+						"unique-string": "1.0.0",
+						"write-file-atomic": "2.4.3",
+						"xdg-basedir": "3.0.0"
 					}
 				},
 				"console-control-strings": {
@@ -7962,12 +7943,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^1.1.1",
-						"fs-write-stream-atomic": "^1.0.8",
-						"iferr": "^0.1.5",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.5.4",
-						"run-queue": "^1.0.0"
+						"aproba": "1.2.0",
+						"fs-write-stream-atomic": "1.0.10",
+						"iferr": "0.1.5",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.3",
+						"run-queue": "1.0.3"
 					},
 					"dependencies": {
 						"aproba": {
@@ -7992,7 +7973,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"capture-stack-trace": "^1.0.0"
+						"capture-stack-trace": "1.0.0"
 					}
 				},
 				"cross-spawn": {
@@ -8000,9 +7981,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"lru-cache": "4.1.5",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					},
 					"dependencies": {
 						"lru-cache": {
@@ -8010,8 +7991,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"pseudomap": "^1.0.2",
-								"yallist": "^2.1.2"
+								"pseudomap": "1.0.2",
+								"yallist": "2.1.2"
 							}
 						},
 						"yallist": {
@@ -8036,7 +8017,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					}
 				},
 				"debug": {
@@ -8079,7 +8060,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"clone": "^1.0.2"
+						"clone": "1.0.4"
 					}
 				},
 				"define-properties": {
@@ -8087,7 +8068,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"object-keys": "^1.0.12"
+						"object-keys": "1.0.12"
 					}
 				},
 				"delayed-stream": {
@@ -8115,8 +8096,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"asap": "^2.0.0",
-						"wrappy": "1"
+						"asap": "2.0.6",
+						"wrappy": "1.0.2"
 					}
 				},
 				"dot-prop": {
@@ -8124,7 +8105,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-obj": "^1.0.0"
+						"is-obj": "1.0.1"
 					}
 				},
 				"dotenv": {
@@ -8142,10 +8123,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"end-of-stream": "^1.0.0",
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.0",
-						"stream-shift": "^1.0.0"
+						"end-of-stream": "1.4.1",
+						"inherits": "2.0.4",
+						"readable-stream": "2.3.6",
+						"stream-shift": "1.0.0"
 					},
 					"dependencies": {
 						"readable-stream": {
@@ -8153,13 +8134,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.2",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"string_decoder": {
@@ -8167,7 +8148,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -8178,8 +8159,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0",
-						"safer-buffer": "^2.1.0"
+						"jsbn": "0.1.1",
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"editor": {
@@ -8192,7 +8173,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"iconv-lite": "~0.4.13"
+						"iconv-lite": "0.4.23"
 					}
 				},
 				"end-of-stream": {
@@ -8200,7 +8181,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"once": "^1.4.0"
+						"once": "1.4.0"
 					}
 				},
 				"env-paths": {
@@ -8218,7 +8199,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"prr": "~1.0.1"
+						"prr": "1.0.1"
 					}
 				},
 				"es-abstract": {
@@ -8226,11 +8207,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"es-to-primitive": "^1.1.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.1",
-						"is-callable": "^1.1.3",
-						"is-regex": "^1.0.4"
+						"es-to-primitive": "1.2.0",
+						"function-bind": "1.1.1",
+						"has": "1.0.3",
+						"is-callable": "1.1.4",
+						"is-regex": "1.0.4"
 					}
 				},
 				"es-to-primitive": {
@@ -8238,9 +8219,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
+						"is-callable": "1.1.4",
+						"is-date-object": "1.0.1",
+						"is-symbol": "1.0.2"
 					}
 				},
 				"es6-promise": {
@@ -8253,7 +8234,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"es6-promise": "^4.0.3"
+						"es6-promise": "4.2.8"
 					}
 				},
 				"escape-string-regexp": {
@@ -8266,13 +8247,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					},
 					"dependencies": {
 						"get-stream": {
@@ -8317,7 +8298,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"flush-write-stream": {
@@ -8325,8 +8306,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.4"
+						"inherits": "2.0.4",
+						"readable-stream": "2.3.6"
 					},
 					"dependencies": {
 						"readable-stream": {
@@ -8334,13 +8315,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.2",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"string_decoder": {
@@ -8348,7 +8329,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -8363,9 +8344,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"asynckit": "^0.4.0",
+						"asynckit": "0.4.0",
 						"combined-stream": "1.0.6",
-						"mime-types": "^2.1.12"
+						"mime-types": "2.1.19"
 					}
 				},
 				"from2": {
@@ -8373,8 +8354,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.0"
+						"inherits": "2.0.4",
+						"readable-stream": "2.3.6"
 					},
 					"dependencies": {
 						"readable-stream": {
@@ -8382,13 +8363,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.2",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"string_decoder": {
@@ -8396,7 +8377,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -8406,7 +8387,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minipass": "^2.6.0"
+						"minipass": "2.9.0"
 					},
 					"dependencies": {
 						"minipass": {
@@ -8414,8 +8395,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
+								"safe-buffer": "5.1.2",
+								"yallist": "3.0.3"
 							}
 						}
 					}
@@ -8425,9 +8406,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"path-is-inside": "^1.0.1",
-						"rimraf": "^2.5.2"
+						"graceful-fs": "4.2.3",
+						"path-is-inside": "1.0.2",
+						"rimraf": "2.6.3"
 					}
 				},
 				"fs-write-stream-atomic": {
@@ -8435,10 +8416,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"iferr": "^0.1.5",
-						"imurmurhash": "^0.1.4",
-						"readable-stream": "1 || 2"
+						"graceful-fs": "4.2.3",
+						"iferr": "0.1.5",
+						"imurmurhash": "0.1.4",
+						"readable-stream": "2.3.6"
 					},
 					"dependencies": {
 						"iferr": {
@@ -8451,13 +8432,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.2",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"string_decoder": {
@@ -8465,7 +8446,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -8485,14 +8466,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					},
 					"dependencies": {
 						"aproba": {
@@ -8505,9 +8486,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -8522,17 +8503,17 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^1.1.2",
-						"chownr": "^1.1.2",
-						"cmd-shim": "^3.0.3",
-						"fs-vacuum": "^1.2.10",
-						"graceful-fs": "^4.1.11",
-						"iferr": "^0.1.5",
-						"infer-owner": "^1.0.4",
-						"mkdirp": "^0.5.1",
-						"path-is-inside": "^1.0.2",
-						"read-cmd-shim": "^1.0.1",
-						"slide": "^1.1.6"
+						"aproba": "1.2.0",
+						"chownr": "1.1.3",
+						"cmd-shim": "3.0.3",
+						"fs-vacuum": "1.2.10",
+						"graceful-fs": "4.2.3",
+						"iferr": "0.1.5",
+						"infer-owner": "1.0.4",
+						"mkdirp": "0.5.1",
+						"path-is-inside": "1.0.2",
+						"read-cmd-shim": "1.0.5",
+						"slide": "1.1.6"
 					},
 					"dependencies": {
 						"aproba": {
@@ -8557,7 +8538,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"pump": "3.0.0"
 					}
 				},
 				"getpass": {
@@ -8565,7 +8546,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					}
 				},
 				"glob": {
@@ -8573,12 +8554,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.4",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"global-dirs": {
@@ -8586,7 +8567,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ini": "^1.3.4"
+						"ini": "1.3.5"
 					}
 				},
 				"got": {
@@ -8594,17 +8575,17 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"create-error-class": "^3.0.0",
-						"duplexer3": "^0.1.4",
-						"get-stream": "^3.0.0",
-						"is-redirect": "^1.0.0",
-						"is-retry-allowed": "^1.0.0",
-						"is-stream": "^1.0.0",
-						"lowercase-keys": "^1.0.0",
-						"safe-buffer": "^5.0.1",
-						"timed-out": "^4.0.0",
-						"unzip-response": "^2.0.1",
-						"url-parse-lax": "^1.0.0"
+						"create-error-class": "3.0.2",
+						"duplexer3": "0.1.4",
+						"get-stream": "3.0.0",
+						"is-redirect": "1.0.0",
+						"is-retry-allowed": "1.1.0",
+						"is-stream": "1.1.0",
+						"lowercase-keys": "1.0.1",
+						"safe-buffer": "5.1.2",
+						"timed-out": "4.0.1",
+						"unzip-response": "2.0.1",
+						"url-parse-lax": "1.0.0"
 					},
 					"dependencies": {
 						"get-stream": {
@@ -8629,8 +8610,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ajv": "^5.3.0",
-						"har-schema": "^2.0.0"
+						"ajv": "5.5.2",
+						"har-schema": "2.0.0"
 					}
 				},
 				"has": {
@@ -8638,7 +8619,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"function-bind": "^1.1.1"
+						"function-bind": "1.1.1"
 					}
 				},
 				"has-flag": {
@@ -8671,7 +8652,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"agent-base": "4",
+						"agent-base": "4.3.0",
 						"debug": "3.1.0"
 					}
 				},
@@ -8680,9 +8661,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"assert-plus": "^1.0.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
+						"assert-plus": "1.0.0",
+						"jsprim": "1.4.1",
+						"sshpk": "1.14.2"
 					}
 				},
 				"https-proxy-agent": {
@@ -8690,8 +8671,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"agent-base": "^4.3.0",
-						"debug": "^3.1.0"
+						"agent-base": "4.3.0",
+						"debug": "3.1.0"
 					}
 				},
 				"humanize-ms": {
@@ -8699,7 +8680,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ms": "^2.0.0"
+						"ms": "2.1.1"
 					}
 				},
 				"iconv-lite": {
@@ -8707,7 +8688,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"iferr": {
@@ -8720,7 +8701,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"import-lazy": {
@@ -8743,8 +8724,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -8762,14 +8743,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.1.1",
-						"npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-						"promzard": "^0.3.0",
-						"read": "~1.0.1",
-						"read-package-json": "1 || 2",
-						"semver": "2.x || 3.x || 4 || 5",
-						"validate-npm-package-license": "^3.0.1",
-						"validate-npm-package-name": "^3.0.0"
+						"glob": "7.1.4",
+						"npm-package-arg": "6.1.1",
+						"promzard": "0.3.0",
+						"read": "1.0.7",
+						"read-package-json": "2.1.1",
+						"semver": "5.7.1",
+						"validate-npm-package-license": "3.0.4",
+						"validate-npm-package-name": "3.0.0"
 					}
 				},
 				"invert-kv": {
@@ -8797,7 +8778,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ci-info": "^1.0.0"
+						"ci-info": "1.6.0"
 					},
 					"dependencies": {
 						"ci-info": {
@@ -8812,7 +8793,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cidr-regex": "^2.0.10"
+						"cidr-regex": "2.0.10"
 					}
 				},
 				"is-date-object": {
@@ -8825,7 +8806,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"is-installed-globally": {
@@ -8833,8 +8814,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"global-dirs": "^0.1.0",
-						"is-path-inside": "^1.0.0"
+						"global-dirs": "0.1.1",
+						"is-path-inside": "1.0.1"
 					}
 				},
 				"is-npm": {
@@ -8852,7 +8833,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"path-is-inside": "^1.0.1"
+						"path-is-inside": "1.0.2"
 					}
 				},
 				"is-redirect": {
@@ -8865,7 +8846,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"has": "^1.0.1"
+						"has": "1.0.3"
 					}
 				},
 				"is-retry-allowed": {
@@ -8883,7 +8864,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"has-symbols": "^1.0.0"
+						"has-symbols": "1.0.0"
 					}
 				},
 				"is-typedarray": {
@@ -8953,7 +8934,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"package-json": "^4.0.0"
+						"package-json": "4.0.1"
 					}
 				},
 				"lazy-property": {
@@ -8966,7 +8947,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"invert-kv": "^1.0.0"
+						"invert-kv": "1.0.0"
 					}
 				},
 				"libcipm": {
@@ -8974,21 +8955,21 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bin-links": "^1.1.2",
-						"bluebird": "^3.5.1",
-						"figgy-pudding": "^3.5.1",
-						"find-npm-prefix": "^1.0.2",
-						"graceful-fs": "^4.1.11",
-						"ini": "^1.3.5",
-						"lock-verify": "^2.0.2",
-						"mkdirp": "^0.5.1",
-						"npm-lifecycle": "^3.0.0",
-						"npm-logical-tree": "^1.2.1",
-						"npm-package-arg": "^6.1.0",
-						"pacote": "^9.1.0",
-						"read-package-json": "^2.0.13",
-						"rimraf": "^2.6.2",
-						"worker-farm": "^1.6.0"
+						"bin-links": "1.1.6",
+						"bluebird": "3.5.5",
+						"figgy-pudding": "3.5.1",
+						"find-npm-prefix": "1.0.2",
+						"graceful-fs": "4.2.3",
+						"ini": "1.3.5",
+						"lock-verify": "2.1.0",
+						"mkdirp": "0.5.1",
+						"npm-lifecycle": "3.1.4",
+						"npm-logical-tree": "1.2.1",
+						"npm-package-arg": "6.1.1",
+						"pacote": "9.5.11",
+						"read-package-json": "2.1.1",
+						"rimraf": "2.6.3",
+						"worker-farm": "1.7.0"
 					}
 				},
 				"libnpm": {
@@ -8996,26 +8977,26 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bin-links": "^1.1.2",
-						"bluebird": "^3.5.3",
-						"find-npm-prefix": "^1.0.2",
-						"libnpmaccess": "^3.0.2",
-						"libnpmconfig": "^1.2.1",
-						"libnpmhook": "^5.0.3",
-						"libnpmorg": "^1.0.1",
-						"libnpmpublish": "^1.1.2",
-						"libnpmsearch": "^2.0.2",
-						"libnpmteam": "^1.0.2",
-						"lock-verify": "^2.0.2",
-						"npm-lifecycle": "^3.0.0",
-						"npm-logical-tree": "^1.2.1",
-						"npm-package-arg": "^6.1.0",
-						"npm-profile": "^4.0.2",
-						"npm-registry-fetch": "^4.0.0",
-						"npmlog": "^4.1.2",
-						"pacote": "^9.5.3",
-						"read-package-json": "^2.0.13",
-						"stringify-package": "^1.0.0"
+						"bin-links": "1.1.6",
+						"bluebird": "3.5.5",
+						"find-npm-prefix": "1.0.2",
+						"libnpmaccess": "3.0.2",
+						"libnpmconfig": "1.2.1",
+						"libnpmhook": "5.0.3",
+						"libnpmorg": "1.0.1",
+						"libnpmpublish": "1.1.2",
+						"libnpmsearch": "2.0.2",
+						"libnpmteam": "1.0.2",
+						"lock-verify": "2.1.0",
+						"npm-lifecycle": "3.1.4",
+						"npm-logical-tree": "1.2.1",
+						"npm-package-arg": "6.1.1",
+						"npm-profile": "4.0.2",
+						"npm-registry-fetch": "4.0.2",
+						"npmlog": "4.1.2",
+						"pacote": "9.5.11",
+						"read-package-json": "2.1.1",
+						"stringify-package": "1.0.1"
 					}
 				},
 				"libnpmaccess": {
@@ -9023,10 +9004,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^2.0.0",
-						"get-stream": "^4.0.0",
-						"npm-package-arg": "^6.1.0",
-						"npm-registry-fetch": "^4.0.0"
+						"aproba": "2.0.0",
+						"get-stream": "4.1.0",
+						"npm-package-arg": "6.1.1",
+						"npm-registry-fetch": "4.0.2"
 					}
 				},
 				"libnpmconfig": {
@@ -9034,9 +9015,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"figgy-pudding": "^3.5.1",
-						"find-up": "^3.0.0",
-						"ini": "^1.3.5"
+						"figgy-pudding": "3.5.1",
+						"find-up": "3.0.0",
+						"ini": "1.3.5"
 					},
 					"dependencies": {
 						"find-up": {
@@ -9044,7 +9025,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"locate-path": "^3.0.0"
+								"locate-path": "3.0.0"
 							}
 						},
 						"locate-path": {
@@ -9052,8 +9033,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
+								"p-locate": "3.0.0",
+								"path-exists": "3.0.0"
 							}
 						},
 						"p-limit": {
@@ -9061,7 +9042,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-try": "^2.0.0"
+								"p-try": "2.2.0"
 							}
 						},
 						"p-locate": {
@@ -9069,7 +9050,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"p-limit": "^2.0.0"
+								"p-limit": "2.2.0"
 							}
 						},
 						"p-try": {
@@ -9084,10 +9065,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^2.0.0",
-						"figgy-pudding": "^3.4.1",
-						"get-stream": "^4.0.0",
-						"npm-registry-fetch": "^4.0.0"
+						"aproba": "2.0.0",
+						"figgy-pudding": "3.5.1",
+						"get-stream": "4.1.0",
+						"npm-registry-fetch": "4.0.2"
 					}
 				},
 				"libnpmorg": {
@@ -9095,10 +9076,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^2.0.0",
-						"figgy-pudding": "^3.4.1",
-						"get-stream": "^4.0.0",
-						"npm-registry-fetch": "^4.0.0"
+						"aproba": "2.0.0",
+						"figgy-pudding": "3.5.1",
+						"get-stream": "4.1.0",
+						"npm-registry-fetch": "4.0.2"
 					}
 				},
 				"libnpmpublish": {
@@ -9106,15 +9087,15 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^2.0.0",
-						"figgy-pudding": "^3.5.1",
-						"get-stream": "^4.0.0",
-						"lodash.clonedeep": "^4.5.0",
-						"normalize-package-data": "^2.4.0",
-						"npm-package-arg": "^6.1.0",
-						"npm-registry-fetch": "^4.0.0",
-						"semver": "^5.5.1",
-						"ssri": "^6.0.1"
+						"aproba": "2.0.0",
+						"figgy-pudding": "3.5.1",
+						"get-stream": "4.1.0",
+						"lodash.clonedeep": "4.5.0",
+						"normalize-package-data": "2.5.0",
+						"npm-package-arg": "6.1.1",
+						"npm-registry-fetch": "4.0.2",
+						"semver": "5.7.1",
+						"ssri": "6.0.1"
 					}
 				},
 				"libnpmsearch": {
@@ -9122,9 +9103,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"figgy-pudding": "^3.5.1",
-						"get-stream": "^4.0.0",
-						"npm-registry-fetch": "^4.0.0"
+						"figgy-pudding": "3.5.1",
+						"get-stream": "4.1.0",
+						"npm-registry-fetch": "4.0.2"
 					}
 				},
 				"libnpmteam": {
@@ -9132,10 +9113,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^2.0.0",
-						"figgy-pudding": "^3.4.1",
-						"get-stream": "^4.0.0",
-						"npm-registry-fetch": "^4.0.0"
+						"aproba": "2.0.0",
+						"figgy-pudding": "3.5.1",
+						"get-stream": "4.1.0",
+						"npm-registry-fetch": "4.0.2"
 					}
 				},
 				"libnpx": {
@@ -9143,14 +9124,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"dotenv": "^5.0.1",
-						"npm-package-arg": "^6.0.0",
-						"rimraf": "^2.6.2",
-						"safe-buffer": "^5.1.0",
-						"update-notifier": "^2.3.0",
-						"which": "^1.3.0",
-						"y18n": "^4.0.0",
-						"yargs": "^11.0.0"
+						"dotenv": "5.0.1",
+						"npm-package-arg": "6.1.1",
+						"rimraf": "2.6.3",
+						"safe-buffer": "5.1.2",
+						"update-notifier": "2.5.0",
+						"which": "1.3.1",
+						"y18n": "4.0.0",
+						"yargs": "11.0.0"
 					}
 				},
 				"locate-path": {
@@ -9158,8 +9139,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
 					}
 				},
 				"lock-verify": {
@@ -9167,8 +9148,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"npm-package-arg": "^6.1.0",
-						"semver": "^5.4.1"
+						"npm-package-arg": "6.1.1",
+						"semver": "5.7.1"
 					}
 				},
 				"lockfile": {
@@ -9176,7 +9157,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"signal-exit": "^3.0.2"
+						"signal-exit": "3.0.2"
 					}
 				},
 				"lodash._baseindexof": {
@@ -9189,8 +9170,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"lodash._createset": "~4.0.0",
-						"lodash._root": "~3.0.0"
+						"lodash._createset": "4.0.3",
+						"lodash._root": "3.0.1"
 					}
 				},
 				"lodash._bindcallback": {
@@ -9208,7 +9189,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"lodash._getnative": "^3.0.0"
+						"lodash._getnative": "3.9.1"
 					}
 				},
 				"lodash._createset": {
@@ -9261,7 +9242,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"yallist": "^3.0.2"
+						"yallist": "3.0.3"
 					}
 				},
 				"make-dir": {
@@ -9269,7 +9250,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				},
 				"make-fetch-happen": {
@@ -9277,17 +9258,17 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"agentkeepalive": "^3.4.1",
-						"cacache": "^12.0.0",
-						"http-cache-semantics": "^3.8.1",
-						"http-proxy-agent": "^2.1.0",
-						"https-proxy-agent": "^2.2.3",
-						"lru-cache": "^5.1.1",
-						"mississippi": "^3.0.0",
-						"node-fetch-npm": "^2.0.2",
-						"promise-retry": "^1.1.1",
-						"socks-proxy-agent": "^4.0.0",
-						"ssri": "^6.0.0"
+						"agentkeepalive": "3.5.2",
+						"cacache": "12.0.3",
+						"http-cache-semantics": "3.8.1",
+						"http-proxy-agent": "2.1.0",
+						"https-proxy-agent": "2.2.4",
+						"lru-cache": "5.1.1",
+						"mississippi": "3.0.0",
+						"node-fetch-npm": "2.0.2",
+						"promise-retry": "1.1.1",
+						"socks-proxy-agent": "4.0.2",
+						"ssri": "6.0.1"
 					}
 				},
 				"meant": {
@@ -9300,7 +9281,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
+						"mimic-fn": "1.2.0"
 					}
 				},
 				"mime-db": {
@@ -9313,7 +9294,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mime-db": "~1.35.0"
+						"mime-db": "1.35.0"
 					}
 				},
 				"mimic-fn": {
@@ -9326,7 +9307,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -9339,7 +9320,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minipass": "^2.9.0"
+						"minipass": "2.9.0"
 					},
 					"dependencies": {
 						"minipass": {
@@ -9347,8 +9328,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
+								"safe-buffer": "5.1.2",
+								"yallist": "3.0.3"
 							}
 						}
 					}
@@ -9358,16 +9339,16 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"concat-stream": "^1.5.0",
-						"duplexify": "^3.4.2",
-						"end-of-stream": "^1.1.0",
-						"flush-write-stream": "^1.0.0",
-						"from2": "^2.1.0",
-						"parallel-transform": "^1.1.0",
-						"pump": "^3.0.0",
-						"pumpify": "^1.3.3",
-						"stream-each": "^1.1.0",
-						"through2": "^2.0.0"
+						"concat-stream": "1.6.2",
+						"duplexify": "3.6.0",
+						"end-of-stream": "1.4.1",
+						"flush-write-stream": "1.0.3",
+						"from2": "2.3.0",
+						"parallel-transform": "1.1.0",
+						"pump": "3.0.0",
+						"pumpify": "1.5.1",
+						"stream-each": "1.2.2",
+						"through2": "2.0.3"
 					}
 				},
 				"mkdirp": {
@@ -9383,12 +9364,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^1.1.1",
-						"copy-concurrently": "^1.0.0",
-						"fs-write-stream-atomic": "^1.0.8",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.5.4",
-						"run-queue": "^1.0.3"
+						"aproba": "1.2.0",
+						"copy-concurrently": "1.0.5",
+						"fs-write-stream-atomic": "1.0.10",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.3",
+						"run-queue": "1.0.3"
 					},
 					"dependencies": {
 						"aproba": {
@@ -9413,9 +9394,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"encoding": "^0.1.11",
-						"json-parse-better-errors": "^1.0.0",
-						"safe-buffer": "^5.1.1"
+						"encoding": "0.1.12",
+						"json-parse-better-errors": "1.0.2",
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"node-gyp": {
@@ -9423,17 +9404,17 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"env-paths": "^1.0.0",
-						"glob": "^7.0.3",
-						"graceful-fs": "^4.1.2",
-						"mkdirp": "^0.5.0",
-						"nopt": "2 || 3",
-						"npmlog": "0 || 1 || 2 || 3 || 4",
-						"request": "^2.87.0",
-						"rimraf": "2",
-						"semver": "~5.3.0",
-						"tar": "^4.4.12",
-						"which": "1"
+						"env-paths": "1.0.0",
+						"glob": "7.1.4",
+						"graceful-fs": "4.2.3",
+						"mkdirp": "0.5.1",
+						"nopt": "3.0.6",
+						"npmlog": "4.1.2",
+						"request": "2.88.0",
+						"rimraf": "2.6.3",
+						"semver": "5.3.0",
+						"tar": "4.4.13",
+						"which": "1.3.1"
 					},
 					"dependencies": {
 						"nopt": {
@@ -9441,7 +9422,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"abbrev": "1"
+								"abbrev": "1.1.1"
 							}
 						},
 						"semver": {
@@ -9456,8 +9437,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"normalize-package-data": {
@@ -9465,10 +9446,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"resolve": "^1.10.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
+						"hosted-git-info": "2.8.5",
+						"resolve": "1.10.0",
+						"semver": "5.7.1",
+						"validate-npm-package-license": "3.0.4"
 					},
 					"dependencies": {
 						"resolve": {
@@ -9476,7 +9457,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"path-parse": "^1.0.6"
+								"path-parse": "1.0.6"
 							}
 						}
 					}
@@ -9486,8 +9467,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cli-table3": "^0.5.0",
-						"console-control-strings": "^1.1.0"
+						"cli-table3": "0.5.1",
+						"console-control-strings": "1.1.0"
 					}
 				},
 				"npm-bundled": {
@@ -9495,7 +9476,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"npm-normalize-package-bin": "^1.0.1"
+						"npm-normalize-package-bin": "1.0.1"
 					}
 				},
 				"npm-cache-filename": {
@@ -9508,7 +9489,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"semver": "^2.3.0 || 3.x || 4 || 5"
+						"semver": "5.7.1"
 					}
 				},
 				"npm-lifecycle": {
@@ -9516,14 +9497,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"byline": "^5.0.0",
-						"graceful-fs": "^4.1.15",
-						"node-gyp": "^5.0.2",
-						"resolve-from": "^4.0.0",
-						"slide": "^1.1.6",
+						"byline": "5.0.0",
+						"graceful-fs": "4.2.3",
+						"node-gyp": "5.0.5",
+						"resolve-from": "4.0.0",
+						"slide": "1.1.6",
 						"uid-number": "0.0.6",
-						"umask": "^1.1.0",
-						"which": "^1.3.1"
+						"umask": "1.1.0",
+						"which": "1.3.1"
 					}
 				},
 				"npm-logical-tree": {
@@ -9541,10 +9522,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^2.7.1",
-						"osenv": "^0.1.5",
-						"semver": "^5.6.0",
-						"validate-npm-package-name": "^3.0.0"
+						"hosted-git-info": "2.8.5",
+						"osenv": "0.1.5",
+						"semver": "5.7.1",
+						"validate-npm-package-name": "3.0.0"
 					}
 				},
 				"npm-packlist": {
@@ -9552,8 +9533,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.3",
+						"npm-bundled": "1.1.1"
 					}
 				},
 				"npm-pick-manifest": {
@@ -9561,9 +9542,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"figgy-pudding": "^3.5.1",
-						"npm-package-arg": "^6.0.0",
-						"semver": "^5.4.1"
+						"figgy-pudding": "3.5.1",
+						"npm-package-arg": "6.1.1",
+						"semver": "5.7.1"
 					}
 				},
 				"npm-profile": {
@@ -9571,9 +9552,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^1.1.2 || 2",
-						"figgy-pudding": "^3.4.1",
-						"npm-registry-fetch": "^4.0.0"
+						"aproba": "2.0.0",
+						"figgy-pudding": "3.5.1",
+						"npm-registry-fetch": "4.0.2"
 					}
 				},
 				"npm-registry-fetch": {
@@ -9581,13 +9562,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"JSONStream": "^1.3.4",
-						"bluebird": "^3.5.1",
-						"figgy-pudding": "^3.4.1",
-						"lru-cache": "^5.1.1",
-						"make-fetch-happen": "^5.0.0",
-						"npm-package-arg": "^6.1.0",
-						"safe-buffer": "^5.2.0"
+						"JSONStream": "1.3.5",
+						"bluebird": "3.5.5",
+						"figgy-pudding": "3.5.1",
+						"lru-cache": "5.1.1",
+						"make-fetch-happen": "5.0.2",
+						"npm-package-arg": "6.1.1",
+						"safe-buffer": "5.2.0"
 					},
 					"dependencies": {
 						"safe-buffer": {
@@ -9602,7 +9583,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"path-key": "^2.0.0"
+						"path-key": "2.0.1"
 					}
 				},
 				"npm-user-validate": {
@@ -9615,10 +9596,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -9646,8 +9627,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-properties": "^1.1.2",
-						"es-abstract": "^1.5.1"
+						"define-properties": "1.1.3",
+						"es-abstract": "1.12.0"
 					}
 				},
 				"once": {
@@ -9655,7 +9636,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"opener": {
@@ -9673,9 +9654,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
 					}
 				},
 				"os-tmpdir": {
@@ -9688,8 +9669,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"p-finally": {
@@ -9702,7 +9683,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-try": "^1.0.0"
+						"p-try": "1.0.0"
 					}
 				},
 				"p-locate": {
@@ -9710,7 +9691,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-limit": "1.2.0"
 					}
 				},
 				"p-try": {
@@ -9723,10 +9704,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"got": "^6.7.1",
-						"registry-auth-token": "^3.0.1",
-						"registry-url": "^3.0.3",
-						"semver": "^5.1.0"
+						"got": "6.7.1",
+						"registry-auth-token": "3.3.2",
+						"registry-url": "3.1.0",
+						"semver": "5.7.1"
 					}
 				},
 				"pacote": {
@@ -9734,36 +9715,36 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.3",
-						"cacache": "^12.0.2",
-						"chownr": "^1.1.2",
-						"figgy-pudding": "^3.5.1",
-						"get-stream": "^4.1.0",
-						"glob": "^7.1.3",
-						"infer-owner": "^1.0.4",
-						"lru-cache": "^5.1.1",
-						"make-fetch-happen": "^5.0.0",
-						"minimatch": "^3.0.4",
-						"minipass": "^2.3.5",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"normalize-package-data": "^2.4.0",
-						"npm-normalize-package-bin": "^1.0.0",
-						"npm-package-arg": "^6.1.0",
-						"npm-packlist": "^1.1.12",
-						"npm-pick-manifest": "^3.0.0",
-						"npm-registry-fetch": "^4.0.0",
-						"osenv": "^0.1.5",
-						"promise-inflight": "^1.0.1",
-						"promise-retry": "^1.1.1",
-						"protoduck": "^5.0.1",
-						"rimraf": "^2.6.2",
-						"safe-buffer": "^5.1.2",
-						"semver": "^5.6.0",
-						"ssri": "^6.0.1",
-						"tar": "^4.4.10",
-						"unique-filename": "^1.1.1",
-						"which": "^1.3.1"
+						"bluebird": "3.5.5",
+						"cacache": "12.0.3",
+						"chownr": "1.1.3",
+						"figgy-pudding": "3.5.1",
+						"get-stream": "4.1.0",
+						"glob": "7.1.4",
+						"infer-owner": "1.0.4",
+						"lru-cache": "5.1.1",
+						"make-fetch-happen": "5.0.2",
+						"minimatch": "3.0.4",
+						"minipass": "2.9.0",
+						"mississippi": "3.0.0",
+						"mkdirp": "0.5.1",
+						"normalize-package-data": "2.5.0",
+						"npm-normalize-package-bin": "1.0.1",
+						"npm-package-arg": "6.1.1",
+						"npm-packlist": "1.4.7",
+						"npm-pick-manifest": "3.0.2",
+						"npm-registry-fetch": "4.0.2",
+						"osenv": "0.1.5",
+						"promise-inflight": "1.0.1",
+						"promise-retry": "1.1.1",
+						"protoduck": "5.0.1",
+						"rimraf": "2.6.3",
+						"safe-buffer": "5.1.2",
+						"semver": "5.7.1",
+						"ssri": "6.0.1",
+						"tar": "4.4.13",
+						"unique-filename": "1.1.1",
+						"which": "1.3.1"
 					},
 					"dependencies": {
 						"minipass": {
@@ -9771,8 +9752,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
+								"safe-buffer": "5.1.2",
+								"yallist": "3.0.3"
 							}
 						}
 					}
@@ -9782,9 +9763,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cyclist": "~0.2.2",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.1.5"
+						"cyclist": "0.2.2",
+						"inherits": "2.0.4",
+						"readable-stream": "2.3.6"
 					},
 					"dependencies": {
 						"readable-stream": {
@@ -9792,13 +9773,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.2",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"string_decoder": {
@@ -9806,7 +9787,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -9866,8 +9847,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"err-code": "^1.0.0",
-						"retry": "^0.10.0"
+						"err-code": "1.1.2",
+						"retry": "0.10.1"
 					},
 					"dependencies": {
 						"retry": {
@@ -9882,7 +9863,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"read": "1"
+						"read": "1.0.7"
 					}
 				},
 				"proto-list": {
@@ -9895,7 +9876,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"genfun": "^5.0.0"
+						"genfun": "5.0.0"
 					}
 				},
 				"prr": {
@@ -9918,8 +9899,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
+						"end-of-stream": "1.4.1",
+						"once": "1.4.0"
 					}
 				},
 				"pumpify": {
@@ -9927,9 +9908,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"duplexify": "^3.6.0",
-						"inherits": "^2.0.3",
-						"pump": "^2.0.0"
+						"duplexify": "3.6.0",
+						"inherits": "2.0.4",
+						"pump": "2.0.1"
 					},
 					"dependencies": {
 						"pump": {
@@ -9937,8 +9918,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"end-of-stream": "^1.1.0",
-								"once": "^1.3.1"
+								"end-of-stream": "1.4.1",
+								"once": "1.4.0"
 							}
 						}
 					}
@@ -9963,9 +9944,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"decode-uri-component": "^0.2.0",
-						"split-on-first": "^1.0.0",
-						"strict-uri-encode": "^2.0.0"
+						"decode-uri-component": "0.2.0",
+						"split-on-first": "1.1.0",
+						"strict-uri-encode": "2.0.0"
 					}
 				},
 				"qw": {
@@ -9978,10 +9959,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.5.1",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -9996,7 +9977,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mute-stream": "~0.0.4"
+						"mute-stream": "0.0.7"
 					}
 				},
 				"read-cmd-shim": {
@@ -10004,7 +9985,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2"
+						"graceful-fs": "4.2.3"
 					}
 				},
 				"read-installed": {
@@ -10012,13 +9993,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debuglog": "^1.0.1",
-						"graceful-fs": "^4.1.2",
-						"read-package-json": "^2.0.0",
-						"readdir-scoped-modules": "^1.0.0",
-						"semver": "2 || 3 || 4 || 5",
-						"slide": "~1.1.3",
-						"util-extend": "^1.0.1"
+						"debuglog": "1.0.1",
+						"graceful-fs": "4.2.3",
+						"read-package-json": "2.1.1",
+						"readdir-scoped-modules": "1.1.0",
+						"semver": "5.7.1",
+						"slide": "1.1.6",
+						"util-extend": "1.0.3"
 					}
 				},
 				"read-package-json": {
@@ -10026,11 +10007,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.1.1",
-						"graceful-fs": "^4.1.2",
-						"json-parse-better-errors": "^1.0.1",
-						"normalize-package-data": "^2.0.0",
-						"npm-normalize-package-bin": "^1.0.0"
+						"glob": "7.1.4",
+						"graceful-fs": "4.2.3",
+						"json-parse-better-errors": "1.0.2",
+						"normalize-package-data": "2.5.0",
+						"npm-normalize-package-bin": "1.0.1"
 					}
 				},
 				"read-package-tree": {
@@ -10038,9 +10019,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"read-package-json": "^2.0.0",
-						"readdir-scoped-modules": "^1.0.0",
-						"util-promisify": "^2.1.0"
+						"read-package-json": "2.1.1",
+						"readdir-scoped-modules": "1.1.0",
+						"util-promisify": "2.1.0"
 					}
 				},
 				"readable-stream": {
@@ -10048,9 +10029,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
+						"inherits": "2.0.4",
+						"string_decoder": "1.2.0",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"readdir-scoped-modules": {
@@ -10058,10 +10039,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debuglog": "^1.0.1",
-						"dezalgo": "^1.0.0",
-						"graceful-fs": "^4.1.2",
-						"once": "^1.3.0"
+						"debuglog": "1.0.1",
+						"dezalgo": "1.0.3",
+						"graceful-fs": "4.2.3",
+						"once": "1.4.0"
 					}
 				},
 				"registry-auth-token": {
@@ -10069,8 +10050,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"rc": "^1.1.6",
-						"safe-buffer": "^5.0.1"
+						"rc": "1.2.7",
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"registry-url": {
@@ -10078,7 +10059,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"rc": "^1.0.1"
+						"rc": "1.2.7"
 					}
 				},
 				"request": {
@@ -10086,26 +10067,26 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.8.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.6",
-						"extend": "~3.0.2",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.19",
-						"oauth-sign": "~0.9.0",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.2",
-						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
+						"aws-sign2": "0.7.0",
+						"aws4": "1.8.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.6",
+						"extend": "3.0.2",
+						"forever-agent": "0.6.1",
+						"form-data": "2.3.2",
+						"har-validator": "5.1.0",
+						"http-signature": "1.2.0",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.19",
+						"oauth-sign": "0.9.0",
+						"performance-now": "2.1.0",
+						"qs": "6.5.2",
+						"safe-buffer": "5.1.2",
+						"tough-cookie": "2.4.3",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.3.3"
 					}
 				},
 				"require-directory": {
@@ -10133,7 +10114,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.1.3"
+						"glob": "7.1.4"
 					}
 				},
 				"run-queue": {
@@ -10141,7 +10122,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"aproba": "^1.1.1"
+						"aproba": "1.2.0"
 					},
 					"dependencies": {
 						"aproba": {
@@ -10171,7 +10152,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"semver": "^5.0.3"
+						"semver": "5.7.1"
 					}
 				},
 				"set-blocking": {
@@ -10184,7 +10165,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2"
+						"graceful-fs": "4.2.3"
 					}
 				},
 				"shebang-command": {
@@ -10192,7 +10173,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"shebang-regex": "^1.0.0"
+						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -10221,7 +10202,7 @@
 					"dev": true,
 					"requires": {
 						"ip": "1.1.5",
-						"smart-buffer": "^4.1.0"
+						"smart-buffer": "4.1.0"
 					}
 				},
 				"socks-proxy-agent": {
@@ -10229,8 +10210,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"agent-base": "~4.2.1",
-						"socks": "~2.3.2"
+						"agent-base": "4.2.1",
+						"socks": "2.3.3"
 					},
 					"dependencies": {
 						"agent-base": {
@@ -10238,7 +10219,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"es6-promisify": "^5.0.0"
+								"es6-promisify": "5.0.0"
 							}
 						}
 					}
@@ -10253,8 +10234,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"from2": "^1.3.0",
-						"stream-iterate": "^1.1.0"
+						"from2": "1.3.0",
+						"stream-iterate": "1.2.0"
 					},
 					"dependencies": {
 						"from2": {
@@ -10262,8 +10243,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"inherits": "~2.0.1",
-								"readable-stream": "~1.1.10"
+								"inherits": "2.0.4",
+								"readable-stream": "1.1.14"
 							}
 						},
 						"isarray": {
@@ -10276,10 +10257,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.1",
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
 								"isarray": "0.0.1",
-								"string_decoder": "~0.10.x"
+								"string_decoder": "0.10.31"
 							}
 						},
 						"string_decoder": {
@@ -10294,8 +10275,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "^3.0.0",
-						"spdx-license-ids": "^3.0.0"
+						"spdx-expression-parse": "3.0.0",
+						"spdx-license-ids": "3.0.3"
 					}
 				},
 				"spdx-exceptions": {
@@ -10308,8 +10289,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "^2.1.0",
-						"spdx-license-ids": "^3.0.0"
+						"spdx-exceptions": "2.1.0",
+						"spdx-license-ids": "3.0.3"
 					}
 				},
 				"spdx-license-ids": {
@@ -10327,15 +10308,15 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"asn1": "~0.2.3",
-						"assert-plus": "^1.0.0",
-						"bcrypt-pbkdf": "^1.0.0",
-						"dashdash": "^1.12.0",
-						"ecc-jsbn": "~0.1.1",
-						"getpass": "^0.1.1",
-						"jsbn": "~0.1.0",
-						"safer-buffer": "^2.0.2",
-						"tweetnacl": "~0.14.0"
+						"asn1": "0.2.4",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.2",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.2",
+						"getpass": "0.1.7",
+						"jsbn": "0.1.1",
+						"safer-buffer": "2.1.2",
+						"tweetnacl": "0.14.5"
 					}
 				},
 				"ssri": {
@@ -10343,7 +10324,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"figgy-pudding": "^3.5.1"
+						"figgy-pudding": "3.5.1"
 					}
 				},
 				"stream-each": {
@@ -10351,8 +10332,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"end-of-stream": "^1.1.0",
-						"stream-shift": "^1.0.0"
+						"end-of-stream": "1.4.1",
+						"stream-shift": "1.0.0"
 					}
 				},
 				"stream-iterate": {
@@ -10360,8 +10341,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"readable-stream": "^2.1.5",
-						"stream-shift": "^1.0.0"
+						"readable-stream": "2.3.6",
+						"stream-shift": "1.0.0"
 					},
 					"dependencies": {
 						"readable-stream": {
@@ -10369,13 +10350,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.2",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"string_decoder": {
@@ -10383,7 +10364,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -10403,8 +10384,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -10422,7 +10403,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "3.0.0"
 							}
 						}
 					}
@@ -10432,7 +10413,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"stringify-package": {
@@ -10445,7 +10426,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-eof": {
@@ -10463,7 +10444,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				},
 				"tar": {
@@ -10471,13 +10452,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
+						"chownr": "1.1.3",
+						"fs-minipass": "1.2.7",
+						"minipass": "2.9.0",
+						"minizlib": "1.3.3",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.2",
+						"yallist": "3.0.3"
 					},
 					"dependencies": {
 						"minipass": {
@@ -10485,8 +10466,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
+								"safe-buffer": "5.1.2",
+								"yallist": "3.0.3"
 							}
 						}
 					}
@@ -10496,7 +10477,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"execa": "^0.7.0"
+						"execa": "0.7.0"
 					}
 				},
 				"text-table": {
@@ -10514,8 +10495,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"readable-stream": "^2.1.5",
-						"xtend": "~4.0.1"
+						"readable-stream": "2.3.6",
+						"xtend": "4.0.1"
 					},
 					"dependencies": {
 						"readable-stream": {
@@ -10523,13 +10504,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.4",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.2",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"string_decoder": {
@@ -10537,7 +10518,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -10557,8 +10538,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
+						"psl": "1.1.29",
+						"punycode": "1.4.1"
 					}
 				},
 				"tunnel-agent": {
@@ -10566,7 +10547,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"tweetnacl": {
@@ -10595,7 +10576,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"unique-slug": "^2.0.0"
+						"unique-slug": "2.0.0"
 					}
 				},
 				"unique-slug": {
@@ -10603,7 +10584,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"imurmurhash": "^0.1.4"
+						"imurmurhash": "0.1.4"
 					}
 				},
 				"unique-string": {
@@ -10611,7 +10592,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"crypto-random-string": "^1.0.0"
+						"crypto-random-string": "1.0.0"
 					}
 				},
 				"unpipe": {
@@ -10629,16 +10610,16 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"boxen": "^1.2.1",
-						"chalk": "^2.0.1",
-						"configstore": "^3.0.0",
-						"import-lazy": "^2.1.0",
-						"is-ci": "^1.0.10",
-						"is-installed-globally": "^0.1.0",
-						"is-npm": "^1.0.0",
-						"latest-version": "^3.0.0",
-						"semver-diff": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
+						"boxen": "1.3.0",
+						"chalk": "2.4.1",
+						"configstore": "3.1.2",
+						"import-lazy": "2.1.0",
+						"is-ci": "1.1.0",
+						"is-installed-globally": "0.1.0",
+						"is-npm": "1.0.0",
+						"latest-version": "3.1.0",
+						"semver-diff": "2.1.0",
+						"xdg-basedir": "3.0.0"
 					}
 				},
 				"url-parse-lax": {
@@ -10646,7 +10627,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"prepend-http": "^1.0.1"
+						"prepend-http": "1.0.4"
 					}
 				},
 				"util-deprecate": {
@@ -10664,7 +10645,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"object.getownpropertydescriptors": "^2.0.3"
+						"object.getownpropertydescriptors": "2.0.3"
 					}
 				},
 				"uuid": {
@@ -10677,8 +10658,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-correct": "^3.0.0",
-						"spdx-expression-parse": "^3.0.0"
+						"spdx-correct": "3.0.0",
+						"spdx-expression-parse": "3.0.0"
 					}
 				},
 				"validate-npm-package-name": {
@@ -10686,7 +10667,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"builtins": "^1.0.3"
+						"builtins": "1.0.3"
 					}
 				},
 				"verror": {
@@ -10694,9 +10675,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"assert-plus": "^1.0.0",
+						"assert-plus": "1.0.0",
 						"core-util-is": "1.0.2",
-						"extsprintf": "^1.2.0"
+						"extsprintf": "1.3.0"
 					}
 				},
 				"wcwidth": {
@@ -10704,7 +10685,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"defaults": "^1.0.3"
+						"defaults": "1.0.3"
 					}
 				},
 				"which": {
@@ -10712,7 +10693,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isexe": "^2.0.0"
+						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
@@ -10725,7 +10706,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					},
 					"dependencies": {
 						"string-width": {
@@ -10733,9 +10714,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -10745,7 +10726,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1"
+						"string-width": "2.1.1"
 					}
 				},
 				"worker-farm": {
@@ -10753,7 +10734,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"errno": "~0.1.7"
+						"errno": "0.1.7"
 					}
 				},
 				"wrap-ansi": {
@@ -10761,8 +10742,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
 					},
 					"dependencies": {
 						"string-width": {
@@ -10770,9 +10751,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -10787,9 +10768,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.2"
+						"graceful-fs": "4.2.3",
+						"imurmurhash": "0.1.4",
+						"signal-exit": "3.0.2"
 					}
 				},
 				"xdg-basedir": {
@@ -10817,18 +10798,18 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
 					},
 					"dependencies": {
 						"y18n": {
@@ -10843,7 +10824,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -10854,7 +10835,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"number-is-nan": {
@@ -10881,9 +10862,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -10892,7 +10873,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"kind-of": {
@@ -10901,7 +10882,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -10918,7 +10899,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -10927,8 +10908,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"define-properties": "1.1.3",
+				"es-abstract": "1.13.0"
 			}
 		},
 		"object.pick": {
@@ -10937,7 +10918,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"octokit-pagination-methods": {
@@ -10952,7 +10933,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -10961,7 +10942,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"optimist": {
@@ -10970,8 +10951,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
+				"minimist": "0.0.10",
+				"wordwrap": "0.0.3"
 			},
 			"dependencies": {
 				"minimist": {
@@ -10988,12 +10969,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -11010,8 +10991,8 @@
 			"integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
 			"dev": true,
 			"requires": {
-				"macos-release": "^2.2.0",
-				"windows-release": "^3.1.0"
+				"macos-release": "2.3.0",
+				"windows-release": "3.2.0"
 			}
 		},
 		"os-tmpdir": {
@@ -11026,7 +11007,7 @@
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
 			"dev": true,
 			"requires": {
-				"p-reduce": "^1.0.0"
+				"p-reduce": "1.0.0"
 			},
 			"dependencies": {
 				"p-reduce": {
@@ -11043,7 +11024,7 @@
 			"integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
 			"dev": true,
 			"requires": {
-				"p-map": "^2.0.0"
+				"p-map": "2.1.0"
 			}
 		},
 		"p-finally": {
@@ -11064,7 +11045,7 @@
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -11073,7 +11054,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.3.0"
 			}
 		},
 		"p-map": {
@@ -11094,8 +11075,8 @@
 			"integrity": "sha512-oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==",
 			"dev": true,
 			"requires": {
-				"@types/retry": "^0.12.0",
-				"retry": "^0.12.0"
+				"@types/retry": "0.12.0",
+				"retry": "0.12.0"
 			}
 		},
 		"p-try": {
@@ -11110,7 +11091,7 @@
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"requires": {
-				"callsites": "^3.0.0"
+				"callsites": "3.1.0"
 			}
 		},
 		"parse-github-url": {
@@ -11125,8 +11106,8 @@
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
+				"error-ex": "1.3.2",
+				"json-parse-better-errors": "1.0.2"
 			}
 		},
 		"parse-passwd": {
@@ -11177,7 +11158,7 @@
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			}
 		},
 		"performance-now": {
@@ -11204,7 +11185,7 @@
 			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
 			"dev": true,
 			"requires": {
-				"node-modules-regexp": "^1.0.0"
+				"node-modules-regexp": "1.0.0"
 			}
 		},
 		"pkg-conf": {
@@ -11213,8 +11194,8 @@
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.0.0",
-				"load-json-file": "^4.0.0"
+				"find-up": "2.1.0",
+				"load-json-file": "4.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -11223,7 +11204,7 @@
 			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"dev": true,
 			"requires": {
-				"find-up": "^3.0.0"
+				"find-up": "3.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -11232,7 +11213,7 @@
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"locate-path": "3.0.0"
 					}
 				},
 				"locate-path": {
@@ -11241,8 +11222,8 @@
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "3.0.0",
+						"path-exists": "3.0.0"
 					}
 				},
 				"p-limit": {
@@ -11251,7 +11232,7 @@
 					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"p-try": "2.2.0"
 					}
 				},
 				"p-locate": {
@@ -11260,7 +11241,7 @@
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "2.2.1"
 					}
 				},
 				"p-try": {
@@ -11295,10 +11276,10 @@
 			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"ansi-regex": "^4.0.0",
-				"ansi-styles": "^3.2.0",
-				"react-is": "^16.8.4"
+				"@jest/types": "24.9.0",
+				"ansi-regex": "4.1.0",
+				"ansi-styles": "3.2.1",
+				"react-is": "16.9.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11327,8 +11308,8 @@
 			"integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
 			"dev": true,
 			"requires": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.3"
+				"kleur": "3.0.3",
+				"sisteransi": "1.0.3"
 			}
 		},
 		"psl": {
@@ -11343,8 +11324,8 @@
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
 			}
 		},
 		"punycode": {
@@ -11377,10 +11358,10 @@
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"dev": true,
 			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
+				"deep-extend": "0.6.0",
+				"ini": "1.3.5",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
 			}
 		},
 		"react-is": {
@@ -11395,9 +11376,9 @@
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^4.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^3.0.0"
+				"load-json-file": "4.0.0",
+				"normalize-package-data": "2.5.0",
+				"path-type": "3.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -11406,8 +11387,8 @@
 			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.0.0",
-				"read-pkg": "^3.0.0"
+				"find-up": "2.1.0",
+				"read-pkg": "3.0.0"
 			}
 		},
 		"readable-stream": {
@@ -11416,13 +11397,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.4",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.1",
+				"safe-buffer": "5.1.2",
+				"string_decoder": "1.1.1",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"realpath-native": {
@@ -11431,7 +11412,7 @@
 			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "^1.0.0"
+				"util.promisify": "1.0.0"
 			}
 		},
 		"rechoir": {
@@ -11440,7 +11421,7 @@
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"dev": true,
 			"requires": {
-				"resolve": "^1.1.6"
+				"resolve": "1.11.1"
 			}
 		},
 		"redent": {
@@ -11449,8 +11430,8 @@
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^3.0.0",
-				"strip-indent": "^2.0.0"
+				"indent-string": "3.2.0",
+				"strip-indent": "2.0.0"
 			}
 		},
 		"redeyed": {
@@ -11459,7 +11440,7 @@
 			"integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
 			"dev": true,
 			"requires": {
-				"esprima": "~4.0.0"
+				"esprima": "4.0.1"
 			}
 		},
 		"regenerator-runtime": {
@@ -11474,8 +11455,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regexpp": {
@@ -11490,8 +11471,8 @@
 			"integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
 			"dev": true,
 			"requires": {
-				"rc": "^1.2.8",
-				"safe-buffer": "^5.0.1"
+				"rc": "1.2.8",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"release-rules-peakfijn": {
@@ -11527,26 +11508,26 @@
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.8.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.8",
+				"extend": "3.0.2",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.3",
+				"har-validator": "5.1.3",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.24",
+				"oauth-sign": "0.9.0",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.2",
+				"tough-cookie": "2.4.3",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.3.2"
 			},
 			"dependencies": {
 				"punycode": {
@@ -11561,8 +11542,8 @@
 					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 					"dev": true,
 					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
+						"psl": "1.3.0",
+						"punycode": "1.4.1"
 					}
 				}
 			}
@@ -11573,7 +11554,7 @@
 			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.11"
+				"lodash": "4.17.15"
 			}
 		},
 		"request-promise-native": {
@@ -11583,8 +11564,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.2",
-				"stealthy-require": "^1.1.1",
-				"tough-cookie": "^2.3.3"
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.5.0"
 			}
 		},
 		"require-directory": {
@@ -11605,7 +11586,7 @@
 			"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.6"
+				"path-parse": "1.0.6"
 			}
 		},
 		"resolve-cwd": {
@@ -11614,7 +11595,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -11631,8 +11612,8 @@
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.0",
-				"global-modules": "^1.0.0"
+				"expand-tilde": "2.0.2",
+				"global-modules": "1.0.0"
 			}
 		},
 		"resolve-from": {
@@ -11647,7 +11628,7 @@
 			"integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
 			"dev": true,
 			"requires": {
-				"global-dirs": "^0.1.1"
+				"global-dirs": "0.1.1"
 			}
 		},
 		"resolve-pkg": {
@@ -11656,7 +11637,7 @@
 			"integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^5.0.0"
+				"resolve-from": "5.0.0"
 			}
 		},
 		"resolve-url": {
@@ -11671,8 +11652,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ret": {
@@ -11705,7 +11686,7 @@
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.3"
+				"glob": "7.1.4"
 			}
 		},
 		"rsvp": {
@@ -11720,7 +11701,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"run-parallel": {
@@ -11735,7 +11716,7 @@
 			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.9.0"
+				"tslib": "1.10.0"
 			}
 		},
 		"safe-buffer": {
@@ -11750,7 +11731,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"safer-buffer": {
@@ -11765,15 +11746,15 @@
 			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
 			"dev": true,
 			"requires": {
-				"@cnakazawa/watch": "^1.0.3",
-				"anymatch": "^2.0.0",
-				"capture-exit": "^2.0.0",
-				"exec-sh": "^0.3.2",
-				"execa": "^1.0.0",
-				"fb-watchman": "^2.0.0",
-				"micromatch": "^3.1.4",
-				"minimist": "^1.1.1",
-				"walker": "~1.0.5"
+				"@cnakazawa/watch": "1.0.3",
+				"anymatch": "2.0.0",
+				"capture-exit": "2.0.0",
+				"exec-sh": "0.3.2",
+				"execa": "1.0.0",
+				"fb-watchman": "2.0.0",
+				"micromatch": "3.1.10",
+				"minimist": "1.2.0",
+				"walker": "1.0.7"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -11782,11 +11763,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.5",
+						"path-key": "2.0.1",
+						"semver": "5.7.1",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					}
 				},
 				"execa": {
@@ -11795,13 +11776,13 @@
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "6.0.5",
+						"get-stream": "4.1.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"get-stream": {
@@ -11810,7 +11791,7 @@
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"pump": "3.0.0"
 					}
 				},
 				"semver": {
@@ -11850,10 +11831,10 @@
 			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -11862,7 +11843,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -11873,7 +11854,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -11888,9 +11869,9 @@
 			"integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.0",
-				"interpret": "^1.0.0",
-				"rechoir": "^0.6.2"
+				"glob": "7.1.4",
+				"interpret": "1.2.0",
+				"rechoir": "0.6.2"
 			}
 		},
 		"shellwords": {
@@ -11923,9 +11904,9 @@
 			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"astral-regex": "^1.0.0",
-				"is-fullwidth-code-point": "^2.0.0"
+				"ansi-styles": "3.2.1",
+				"astral-regex": "1.0.0",
+				"is-fullwidth-code-point": "2.0.0"
 			}
 		},
 		"snapdragon": {
@@ -11934,14 +11915,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.2",
+				"use": "3.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -11950,7 +11931,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -11959,7 +11940,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -11970,9 +11951,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -11981,7 +11962,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -11990,7 +11971,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -11999,7 +11980,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -12008,9 +11989,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -12021,7 +12002,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -12030,7 +12011,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -12047,11 +12028,11 @@
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"atob": "^2.1.1",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.2",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -12060,8 +12041,8 @@
 			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
+				"buffer-from": "1.1.1",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12090,8 +12071,8 @@
 			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.5"
 			}
 		},
 		"spdx-exceptions": {
@@ -12106,8 +12087,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.2.0",
+				"spdx-license-ids": "3.0.5"
 			}
 		},
 		"spdx-license-ids": {
@@ -12122,7 +12103,7 @@
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 			"dev": true,
 			"requires": {
-				"through": "2"
+				"through": "2.3.8"
 			}
 		},
 		"split-string": {
@@ -12131,7 +12112,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"split2": {
@@ -12140,7 +12121,7 @@
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 			"dev": true,
 			"requires": {
-				"through2": "^2.0.2"
+				"through2": "2.0.5"
 			}
 		},
 		"sprintf-js": {
@@ -12155,15 +12136,15 @@
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.4",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.2",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.2",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"stack-utils": {
@@ -12178,8 +12159,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -12188,7 +12169,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -12205,8 +12186,8 @@
 			"integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
 			"dev": true,
 			"requires": {
-				"duplexer2": "~0.1.0",
-				"readable-stream": "^2.0.2"
+				"duplexer2": "0.1.4",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"string-length": {
@@ -12215,8 +12196,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
 			}
 		},
 		"string-width": {
@@ -12225,8 +12206,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
 			}
 		},
 		"string_decoder": {
@@ -12235,7 +12216,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"strip-ansi": {
@@ -12244,7 +12225,7 @@
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0"
+				"ansi-regex": "3.0.0"
 			}
 		},
 		"strip-bom": {
@@ -12277,7 +12258,7 @@
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "3.0.0"
 			}
 		},
 		"supports-hyperlinks": {
@@ -12286,8 +12267,8 @@
 			"integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^2.0.0",
-				"supports-color": "^5.0.0"
+				"has-flag": "2.0.0",
+				"supports-color": "5.5.0"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -12310,10 +12291,10 @@
 			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.10.2",
-				"lodash": "^4.17.14",
-				"slice-ansi": "^2.1.0",
-				"string-width": "^3.0.0"
+				"ajv": "6.10.2",
+				"lodash": "4.17.15",
+				"slice-ansi": "2.1.0",
+				"string-width": "3.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -12328,9 +12309,9 @@
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"emoji-regex": "7.0.3",
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "5.2.0"
 					}
 				},
 				"strip-ansi": {
@@ -12339,7 +12320,7 @@
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "4.1.0"
 					}
 				}
 			}
@@ -12350,9 +12331,9 @@
 			"integrity": "sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==",
 			"dev": true,
 			"requires": {
-				"https-proxy-agent": "^2.2.1",
-				"node-fetch": "^2.2.0",
-				"uuid": "^3.3.2"
+				"https-proxy-agent": "2.2.4",
+				"node-fetch": "2.6.0",
+				"uuid": "3.3.2"
 			}
 		},
 		"test-exclude": {
@@ -12361,10 +12342,10 @@
 			"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.3",
-				"minimatch": "^3.0.4",
-				"read-pkg-up": "^4.0.0",
-				"require-main-filename": "^2.0.0"
+				"glob": "7.1.4",
+				"minimatch": "3.0.4",
+				"read-pkg-up": "4.0.0",
+				"require-main-filename": "2.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -12373,7 +12354,7 @@
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"locate-path": "3.0.0"
 					}
 				},
 				"locate-path": {
@@ -12382,8 +12363,8 @@
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "3.0.0",
+						"path-exists": "3.0.0"
 					}
 				},
 				"p-limit": {
@@ -12392,7 +12373,7 @@
 					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"p-try": "2.2.0"
 					}
 				},
 				"p-locate": {
@@ -12401,7 +12382,7 @@
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "2.2.1"
 					}
 				},
 				"p-try": {
@@ -12416,8 +12397,8 @@
 					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
 					"dev": true,
 					"requires": {
-						"find-up": "^3.0.0",
-						"read-pkg": "^3.0.0"
+						"find-up": "3.0.0",
+						"read-pkg": "3.0.0"
 					}
 				}
 			}
@@ -12452,8 +12433,8 @@
 			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "~2.3.6",
-				"xtend": "~4.0.1"
+				"readable-stream": "2.3.6",
+				"xtend": "4.0.2"
 			}
 		},
 		"tmp": {
@@ -12462,7 +12443,7 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"tmpl": {
@@ -12483,7 +12464,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -12492,7 +12473,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -12503,10 +12484,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -12515,8 +12496,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"tough-cookie": {
@@ -12525,8 +12506,8 @@
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
+				"psl": "1.3.0",
+				"punycode": "2.1.1"
 			}
 		},
 		"tr46": {
@@ -12535,7 +12516,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			}
 		},
 		"traverse": {
@@ -12568,16 +12549,16 @@
 			"integrity": "sha512-Yc+HLyldlIC9iIK8xEN7tV960Or56N49MDP7hubCZUeI7EbIOTsas6rXCMB4kQjLACJ7eDOF4xWEO5qumpKsag==",
 			"dev": true,
 			"requires": {
-				"bs-logger": "0.x",
-				"buffer-from": "1.x",
-				"fast-json-stable-stringify": "2.x",
-				"json5": "2.x",
-				"lodash.memoize": "4.x",
-				"make-error": "1.x",
-				"mkdirp": "0.x",
-				"resolve": "1.x",
-				"semver": "^5.5",
-				"yargs-parser": "10.x"
+				"bs-logger": "0.2.6",
+				"buffer-from": "1.1.1",
+				"fast-json-stable-stringify": "2.0.0",
+				"json5": "2.1.0",
+				"lodash.memoize": "4.1.2",
+				"make-error": "1.3.5",
+				"mkdirp": "0.5.1",
+				"resolve": "1.11.1",
+				"semver": "5.7.1",
+				"yargs-parser": "10.1.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -12600,7 +12581,7 @@
 			"integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.8.1"
+				"tslib": "1.10.0"
 			}
 		},
 		"tunnel-agent": {
@@ -12609,7 +12590,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"tweetnacl": {
@@ -12624,7 +12605,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"type-fest": {
@@ -12646,8 +12627,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "~2.20.0",
-				"source-map": "~0.6.1"
+				"commander": "2.20.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12665,10 +12646,10 @@
 			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^2.0.1"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "2.0.1"
 			}
 		},
 		"universal-user-agent": {
@@ -12677,7 +12658,7 @@
 			"integrity": "sha512-T3siHThqoj5X0benA5H0qcDnrKGXzU8TKoX15x/tQHw1hQBvIEBHjxQ2klizYsqBOO/Q+WuxoQUihadeeqDnoA==",
 			"dev": true,
 			"requires": {
-				"os-name": "^3.0.0"
+				"os-name": "3.1.0"
 			}
 		},
 		"universalify": {
@@ -12691,8 +12672,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -12701,9 +12682,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -12731,7 +12712,7 @@
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			}
 		},
 		"urix": {
@@ -12776,8 +12757,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "1.1.3",
+				"object.getownpropertydescriptors": "2.0.3"
 			}
 		},
 		"uuid": {
@@ -12798,8 +12779,8 @@
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.1.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"verror": {
@@ -12808,9 +12789,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"w3c-hr-time": {
@@ -12819,7 +12800,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "^0.1.2"
+				"browser-process-hrtime": "0.1.3"
 			}
 		},
 		"walker": {
@@ -12828,7 +12809,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.x"
+				"makeerror": "1.0.11"
 			}
 		},
 		"webidl-conversions": {
@@ -12858,9 +12839,9 @@
 			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"which": {
@@ -12869,7 +12850,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -12884,7 +12865,7 @@
 			"integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
 			"dev": true,
 			"requires": {
-				"execa": "^1.0.0"
+				"execa": "1.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -12893,11 +12874,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.5",
+						"path-key": "2.0.1",
+						"semver": "5.7.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					}
 				},
 				"execa": {
@@ -12906,13 +12887,13 @@
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "6.0.5",
+						"get-stream": "4.1.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"get-stream": {
@@ -12921,7 +12902,7 @@
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"pump": "3.0.0"
 					}
 				},
 				"semver": {
@@ -12950,9 +12931,9 @@
 			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
+				"ansi-styles": "3.2.1",
+				"string-width": "3.1.0",
+				"strip-ansi": "5.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -12967,9 +12948,9 @@
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"emoji-regex": "7.0.3",
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "5.2.0"
 					}
 				},
 				"strip-ansi": {
@@ -12978,7 +12959,7 @@
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "4.1.0"
 					}
 				}
 			}
@@ -12995,7 +12976,7 @@
 			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -13004,9 +12985,9 @@
 			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"graceful-fs": "4.2.0",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ws": {
@@ -13015,7 +12996,7 @@
 			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "~1.0.0"
+				"async-limiter": "1.0.1"
 			}
 		},
 		"xml-name-validator": {
@@ -13042,16 +13023,16 @@
 			"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
 			"dev": true,
 			"requires": {
-				"cliui": "^5.0.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^13.1.1"
+				"cliui": "5.0.0",
+				"find-up": "3.0.0",
+				"get-caller-file": "2.0.5",
+				"require-directory": "2.1.1",
+				"require-main-filename": "2.0.0",
+				"set-blocking": "2.0.0",
+				"string-width": "3.1.0",
+				"which-module": "2.0.0",
+				"y18n": "4.0.0",
+				"yargs-parser": "13.1.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -13072,7 +13053,7 @@
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"locate-path": "3.0.0"
 					}
 				},
 				"locate-path": {
@@ -13081,8 +13062,8 @@
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "3.0.0",
+						"path-exists": "3.0.0"
 					}
 				},
 				"p-limit": {
@@ -13091,7 +13072,7 @@
 					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"p-try": "2.2.0"
 					}
 				},
 				"p-locate": {
@@ -13100,7 +13081,7 @@
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "2.2.1"
 					}
 				},
 				"p-try": {
@@ -13115,9 +13096,9 @@
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"emoji-regex": "7.0.3",
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "5.2.0"
 					}
 				},
 				"strip-ansi": {
@@ -13126,7 +13107,7 @@
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "4.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -13135,8 +13116,8 @@
 					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
+						"camelcase": "5.3.1",
+						"decamelize": "1.2.0"
 					}
 				}
 			}
@@ -13147,7 +13128,7 @@
 			"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "4.1.0"
 			}
 		}
 	}

--- a/src/version.ts
+++ b/src/version.ts
@@ -21,7 +21,7 @@ export const getVersionCode = (next: SemVer, expo: SemVer) => (
 export const getDefaultVariables = (meta: ManifestMeta, context: Context) => {
 	const expo = coerce(meta.manifest.sdkVersion);
 	const last = coerce(context.lastRelease!.version);
-	const next = coerce(context.nextRelease!.version);
+	const next = new SemVer(context.nextRelease!.version, {includePrerelease: true}); // coerce truncates prerelease tags
 
 	return {
 		code: (next && expo) ? getVersionCode(next, expo) : '000000000',

--- a/test.js
+++ b/test.js
@@ -1,0 +1,23 @@
+const semver = require("semver");
+
+
+function show(asv) 
+{
+//    const sv = semver.coerce(asv, {includePrerelease: true})
+    const sv = new semver.SemVer(asv, {includePrerelease: true});
+
+    console.log(
+        "semver(%s). typeof %s, includePrerelease: %s, loose: %s, version: %s, raw: %s, prerelease.length: %d",
+        asv,
+        typeof sv,
+        sv.options.includePrerelease,
+        sv.options.loose,
+        sv.version,
+        sv.raw,
+        sv.prerelease.length
+    );
+}
+
+show("1.0.1-alpha.27");
+// show("1.0.0-alpha.27");
+// show("1.0.0-alpha.27");

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -49,7 +49,10 @@ describe('version', () => {
 				code: 290030000,
 				expo: coerce('29.0.1'),
 				last: coerce('2.5.12'),
-				next: coerce('3.0.0'),
+				next: {...coerce('3.0.0'),
+					includePrerelease: true,
+					options: {includePrerelease: true}
+				},
 				recommended: '3.0.0',
 			});
 		});
@@ -75,7 +78,10 @@ describe('version', () => {
 		code: 290040600,
 		expo: coerce('29.1.0'),
 		last: coerce('4.5.1'),
-		next: coerce('4.6.0'),
+		next: {...coerce('4.6.0'),
+			includePrerelease: true,
+			options: {includePrerelease: true}
+		},
 		recommended: '4.6.0',
 	};
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"declaration": true,
 		"esModuleInterop": true,
-		"lib": ["es2015"],
+		"lib": ["es2015", "dom"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"outDir": "./build",


### PR DESCRIPTION
…rereleases

### Linked issue
Solves issue #185

### Additional context
Using coerce() when building 'next' and 'last' template variables truncates all prerelease information contained in the version string turning all prerelease related SemVer fields useless when using those variables.

The suggested change only affects 'next' template variable construction (the only one I need) Please consider extending it to last if you find it useful.